### PR TITLE
Handle new technicians when updating Liste

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -176,12 +176,14 @@ def update_liste(
 
     week_index = (day.day - 1) // 7
     start_col = 1 + week_index * 14
+    remaining = set(morning)
 
     for row in range(2, ws.max_row + 1):
         name_cell = ws.cell(row=row, column=1)
         tech = str(name_cell.value).strip() if name_cell.value else None
         if not tech or tech not in morning:
             continue
+        remaining.discard(tech)
         day_data = morning[tech]
         eve_total = evening.get(tech, {}).get("total", 0)
         closed = day_data["total"] - eve_total
@@ -191,6 +193,20 @@ def update_liste(
         ws.cell(row=row, column=start_col + 8).value = day_data["total"]
         ws.cell(row=row, column=start_col + 9).value = day_data["old"]
         ws.cell(row=row, column=start_col + 10).value = day_data["new"]
+
+    for tech in remaining:
+        row = ws.max_row + 1
+        ws.cell(row=row, column=1).value = tech
+        day_data = morning[tech]
+        eve_total = evening.get(tech, {}).get("total", 0)
+        closed = day_data["total"] - eve_total
+        ws.cell(row=row, column=start_col + 1).value = day.toordinal() + 693594
+        ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]
+        ws.cell(row=row, column=start_col + 7).value = closed
+        ws.cell(row=row, column=start_col + 8).value = day_data["total"]
+        ws.cell(row=row, column=start_col + 9).value = day_data["old"]
+        ws.cell(row=row, column=start_col + 10).value = day_data["new"]
+
     wb.save(liste)
 
 


### PR DESCRIPTION
## Summary
- ensure update_liste adds rows to Liste.xlsx when a technician from a report is missing
- populate date, weekday and totals for these newly added technicians

## Testing
- `python -m py_compile process_reports.py`
- `python - <<'PY'
from openpyxl import Workbook
from pathlib import Path
import datetime as dt
from process_reports import update_liste
wb=Workbook(); ws=wb.active; ws.title='Test_25'; ws.cell(row=1,column=1).value='Name'; ws.cell(row=2,column=1).value='Existing Tech'; wb.save('tmp_test.xlsx')
day=dt.date(2025,7,1); morning={'Existing Tech':{'total':3,'new':1,'old':2}, 'New Tech': {'total':2,'new':1,'old':1}}; evening={'Existing Tech':{'total':1}, 'New Tech': {'total':0}}
update_liste(Path('tmp_test.xlsx'),'Test_25', day, morning, evening)
import openpyxl; wb2=openpyxl.load_workbook('tmp_test.xlsx'); ws=wb2['Test_25']
for row in ws.iter_rows(values_only=True):
    print(row)
PY
rm tmp_test.xlsx`

------
https://chatgpt.com/codex/tasks/task_e_688eb47206288330b9ee6346cf802278