### PR TITLE
Fix Excel date handling

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -222,7 +222,7 @@ def update_liste(
         day_data = morning[tech]
         eve_total = evening.get(tech, {}).get("total", 0)
         closed = day_data["total"] - eve_total
-        ws.cell(row=row, column=start_col + 1).value = day.toordinal() + 693594
+        ws.cell(row=row, column=start_col + 1).value = day
         ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]
         ws.cell(row=row, column=start_col + 7).value = closed
         ws.cell(row=row, column=start_col + 8).value = day_data["total"]
@@ -235,7 +235,7 @@ def update_liste(
         day_data = morning[tech]
         eve_total = evening.get(tech, {}).get("total", 0)
         closed = day_data["total"] - eve_total
-        ws.cell(row=row, column=start_col + 1).value = day.toordinal() + 693594
+        ws.cell(row=row, column=start_col + 1).value = day
         ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]
         ws.cell(row=row, column=start_col + 7).value = closed
         ws.cell(row=row, column=start_col + 8).value = day_data["total"]


### PR DESCRIPTION
## Summary
- write `datetime.date` values directly to Excel cells instead of manual ordinal conversion

## Testing
- `python -m py_compile process_reports.py`
- `python process_reports.py Juli_25/01.07 Liste_temp.xlsx`
- `python - <<'PY'
from openpyxl import load_workbook
import datetime as dt
wb = load_workbook('Liste_temp.xlsx', data_only=True)
ws = wb['Juli_25']
found = []
for row in ws.iter_rows(values_only=False):
    for cell in row:
        if isinstance(cell.value, dt.date):
            found.append((cell.coordinate, cell.value))
print('dates found:', len(found))
print(found[:10])
PY`

------
https://chatgpt.com/codex/tasks/task_e_688eb8e8d0948330b14a81b66744b18b