### PR TITLE
Handle reports with multiple sheets

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -137,18 +137,22 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
         technician names via fuzzy comparison.
     """
     wb = safe_load_workbook(path, data_only=True, read_only=True)
-    ws = wb.active
 
     header_row = None
     header_row_idx = None
-    for idx, row in enumerate(
-        ws.iter_rows(min_row=1, max_row=20, values_only=True), 1
-    ):
-        if row and row[0] == HEADER_MARKER:
-            header_row = list(row)
-            header_row_idx = idx
+    ws = None
+    for sheet in wb.worksheets:
+        for idx, row in enumerate(
+            sheet.iter_rows(min_row=1, max_row=20, values_only=True), 1
+        ):
+            if row and row[0] == HEADER_MARKER:
+                header_row = list(row)
+                header_row_idx = idx
+                ws = sheet
+                break
+        if ws is not None:
             break
-    if header_row is None:
+    if ws is None or header_row is None:
         raise ValueError("Header row not found in report")
 
     name_idx = header_row.index("Employee Name")

--- a/tests/test_load_calls.py
+++ b/tests/test_load_calls.py
@@ -1,0 +1,31 @@
+import datetime as dt
+from pathlib import Path
+import sys
+
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from process_reports import load_calls
+
+
+def test_load_calls_selects_correct_sheet(tmp_path):
+    wb = Workbook()
+    ws1 = wb.active
+    ws1["A1"] = "not the sheet"
+
+    ws2 = wb.create_sheet("Report")
+    ws2["A2"] = dt.datetime(2025, 7, 1)
+    ws2["A5"] = "Employee ID"
+    ws2["B5"] = "Employee Name"
+    ws2["C5"] = "Open Date Time"
+    ws2["A6"] = 1
+    ws2["B6"] = "Alice"
+    ws2["C6"] = dt.datetime(2025, 6, 30)
+
+    path = tmp_path / "report.xlsx"
+    wb.save(path)
+
+    target_date, summary = load_calls(path)
+
+    assert target_date == dt.date(2025, 7, 1)
+    assert summary == {"Alice": {"total": 1, "new": 1, "old": 0}}


### PR DESCRIPTION
## Summary
- Update `load_calls` to scan all workbook sheets for the `Employee ID` header
- Add regression test ensuring reports with multiple sheets select the correct sheet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec031e6ac8330a9a7daf336e3c2d4