### PR TITLE
Fix header detection in load_calls

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -145,13 +145,9 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
         for idx, row in enumerate(
             sheet.iter_rows(min_row=1, max_row=20, values_only=True), 1
         ):
-<<<<<<< r4i1tc-codex/update-load_calls-to-iterate-worksheets
             if row and any(
                 cell == HEADER_MARKER for cell in row if isinstance(cell, str)
             ):
-=======
-            if row and row[0] == HEADER_MARKER:
->>>>>>> main
                 header_row = list(row)
                 header_row_idx = idx
                 ws = sheet


### PR DESCRIPTION
## Summary
- search all worksheets for header row by matching any cell containing "Employee ID"

## Testing
- `pytest tests/test_load_calls.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec6ba32bc833084f5c3a21f9c1544