### PR TITLE
Handle technician names case-insensitively

### DIFF
--- a/name_aliases.py
+++ b/name_aliases.py
@@ -4,9 +4,9 @@ from difflib import get_close_matches
 from typing import Iterable
 
 # Map alternate spellings or abbreviations to their canonical form.
-# Extend this mapping as needed.
+# Extend this mapping as needed. Keys are treated case-insensitively.
 ALIASES = {
-    # "Jon Doe": "John Doe",
+    # "jon doe": "John Doe",
 }
 
 
@@ -16,14 +16,20 @@ def canonical_name(name: str, valid_names: Iterable[str], cutoff: float = 0.8) -
     ``valid_names`` should contain the canonical names available in
     ``Liste.xlsx``.  First the static :data:`ALIASES` mapping is checked,
     otherwise :func:`difflib.get_close_matches` is used to find the closest
-    match above ``cutoff``. If no match is found, ``name`` is returned
-    unchanged.
+    match above ``cutoff``. Matching is performed case-insensitively so that
+    names like ``"ALICE"`` still resolve to ``"Alice"``. If no match is found,
+    ``name`` is returned unchanged.
     """
 
     norm = name.strip()
     if not norm:
         return norm
-    if norm in ALIASES:
-        return ALIASES[norm]
-    matches = get_close_matches(norm, list(valid_names), n=1, cutoff=cutoff)
-    return matches[0] if matches else norm
+
+    key = norm.lower()
+    alias_map = {k.lower(): v for k, v in ALIASES.items()}
+    if key in alias_map:
+        return alias_map[key]
+
+    valid_map = {v.lower(): v for v in valid_names}
+    matches = get_close_matches(key, list(valid_map.keys()), n=1, cutoff=cutoff)
+    return valid_map[matches[0]] if matches else norm


### PR DESCRIPTION
## Summary
- Handle aliases and fuzzy matching in a case-insensitive manner so names like `ALICE` resolve to `Alice`
- Note that `ALIASES` keys are treated case-insensitively

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ec7d9513c833093dcd4061c83076a