### PR TITLE
Handle technician names case-insensitively

### DIFF
--- a/name_aliases.py
+++ b/name_aliases.py
@@ -4,10 +4,14 @@ from difflib import get_close_matches
 from typing import Iterable
 
 # Map alternate spellings or abbreviations to their canonical form.
-# Extend this mapping as needed.
+# Extend this mapping as needed. Keys are treated case-insensitively using
+# :py:meth:`str.casefold` for robust comparisons.
 ALIASES = {
-    # "Jon Doe": "John Doe",
+    # "jon doe": "John Doe",
 }
+
+# Pre-compute a case-insensitive lookup so we don't rebuild it on every call.
+_ALIAS_MAP = {k.casefold(): v for k, v in ALIASES.items()}
 
 
 def canonical_name(name: str, valid_names: Iterable[str], cutoff: float = 0.8) -> str:
@@ -16,14 +20,19 @@ def canonical_name(name: str, valid_names: Iterable[str], cutoff: float = 0.8) -
     ``valid_names`` should contain the canonical names available in
     ``Liste.xlsx``.  First the static :data:`ALIASES` mapping is checked,
     otherwise :func:`difflib.get_close_matches` is used to find the closest
-    match above ``cutoff``. If no match is found, ``name`` is returned
-    unchanged.
+    match above ``cutoff``. Matching is performed case-insensitively so that
+    names like ``"ALICE"`` still resolve to ``"Alice"``. If no match is found,
+    ``name`` is returned unchanged.
     """
 
     norm = name.strip()
     if not norm:
         return norm
-    if norm in ALIASES:
-        return ALIASES[norm]
-    matches = get_close_matches(norm, list(valid_names), n=1, cutoff=cutoff)
-    return matches[0] if matches else norm
+
+    key = norm.casefold()
+    if key in _ALIAS_MAP:
+        return _ALIAS_MAP[key]
+
+    valid_map = {v.casefold(): v for v in valid_names}
+    matches = get_close_matches(key, list(valid_map.keys()), n=1, cutoff=cutoff)
+    return valid_map[matches[0]] if matches else norm

--- a/tests/test_name_aliases.py
+++ b/tests/test_name_aliases.py
@@ -1,0 +1,24 @@
+"""Tests for the ``canonical_name`` utility."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import name_aliases as na
+
+
+def test_canonical_name_matches_case_insensitively():
+    """Exact names should match regardless of case."""
+
+    assert na.canonical_name("ALICE", ["Alice"]) == "Alice"
+
+
+def test_alias_lookup_is_case_insensitive(monkeypatch):
+    """Alias keys should be resolved without regard to case."""
+
+    monkeypatch.setitem(na.ALIASES, "bObBy", "Bob")
+    monkeypatch.setitem(na._ALIAS_MAP, "bobby", "Bob")
+
+    assert na.canonical_name("BOBBY", ["Alice", "Bob"]) == "Bob"
+


### PR DESCRIPTION
## Summary
- Precompute a casefolded alias map so each lookup avoids rebuilding the mapping
- Normalize technician names with `str.casefold` before alias and fuzzy matching
- Add tests exercising case-insensitive matching and alias resolution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec7d9513c833093dcd4061c83076a