### PR TITLE
Add assertions for Bob row empty columns in update_liste test

### DIFF
--- a/tests/test_update_liste.py
+++ b/tests/test_update_liste.py
@@ -27,3 +27,5 @@ def test_update_liste(tmp_path: Path):
     assert ws2.cell(row=2, column=9).value == 3
     assert ws2.cell(row=2, column=10).value == 2
     assert ws2.cell(row=2, column=11).value == 1
+    for col in range(8, 12):
+        assert ws2.cell(row=3, column=col).value is None


### PR DESCRIPTION
## Summary
- streamline Bob row 3 validation so columns 8-11 are asserted empty in a loop after running `update_liste`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed20894e48330a5a515554ea165c9