### PR TITLE
Handle empty morning report in update_liste

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -189,6 +189,8 @@ def update_liste(
     evening: Dict[str, Dict[str, int]],
 ):
     """Write aggregated values into the ``Liste.xlsx`` workbook."""
+    if not morning:
+        raise ValueError("Morning report produced no data")
     wb = safe_load_workbook(liste)
     if month_sheet not in wb.sheetnames:
         raise KeyError(f"Worksheet {month_sheet} does not exist in {liste}")

--- a/tests/test_update_liste.py
+++ b/tests/test_update_liste.py
@@ -2,6 +2,7 @@ import datetime as dt
 from pathlib import Path
 
 from openpyxl import Workbook, load_workbook
+import pytest
 
 from process_reports import update_liste
 
@@ -31,3 +32,14 @@ def test_update_liste(tmp_path: Path):
     assert ws2.cell(row=3, column=9).value is None
     assert ws2.cell(row=3, column=10).value is None
     assert ws2.cell(row=3, column=11).value is None
+
+
+def test_update_liste_empty_morning(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    with pytest.raises(ValueError, match="no data"):
+        update_liste(file, "Juli_25", dt.date(2025, 7, 1), {}, {})


### PR DESCRIPTION
## Summary
- Add guard in `update_liste` raising a ValueError when the morning summary is empty
- Test error path for empty morning report

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed3d415308330a004c062d4b550e6