### PR TITLE
Ensure report files are present

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -278,13 +278,25 @@ def main():
     ]
     name_wb.close()
 
-    morning = next(args.day_dir.glob("*7*.xlsx"))
-    evening_file = next(args.day_dir.glob("*19*.xlsx"), None)
+    morning_files = list(args.day_dir.glob("*7*.xlsx"))
+    if not morning_files:
+        raise FileNotFoundError(
+            f"Morning report (*7*.xlsx) not found in {args.day_dir}"
+        )
+    morning = morning_files[0]
+
+    evening_files = list(args.day_dir.glob("*19*.xlsx"))
+    if not evening_files:
+        raise FileNotFoundError(
+            f"Evening report (*19*.xlsx) not found in {args.day_dir}"
+        )
+    evening_file = evening_files[0]
+
     target_date, morning_summary = load_calls(morning, valid_names)
-    evening_summary: Dict[str, Dict[str, int]] = {}
-    if evening_file:
-        _, evening_summary = load_calls(evening_file, valid_names)
-    update_liste(args.liste, month_sheet, target_date, morning_summary, evening_summary)
+    _, evening_summary = load_calls(evening_file, valid_names)
+    update_liste(
+        args.liste, month_sheet, target_date, morning_summary, evening_summary
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_main_missing_files.py
+++ b/tests/test_main_missing_files.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+
+import pytest
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from process_reports import main
+
+
+def create_liste(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    wb.save(path)
+
+
+def test_main_missing_morning_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    liste = tmp_path / "Liste.xlsx"
+    create_liste(liste)
+
+    day_dir = tmp_path / "01.07"
+    day_dir.mkdir()
+
+    # create an evening file to ensure only morning is missing
+    wb = Workbook()
+    wb.save(day_dir / "evening19.xlsx")
+
+    monkeypatch.setattr(sys, "argv", ["process_reports.py", str(day_dir), str(liste)])
+    with pytest.raises(FileNotFoundError) as excinfo:
+        main()
+    assert "Morning report" in str(excinfo.value)
+    assert str(day_dir) in str(excinfo.value)
+
+
+def test_main_missing_evening_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    liste = tmp_path / "Liste.xlsx"
+    create_liste(liste)
+
+    day_dir = tmp_path / "01.07"
+    day_dir.mkdir()
+
+    # create a morning file but no evening file
+    wb = Workbook()
+    wb.save(day_dir / "morning7.xlsx")
+
+    monkeypatch.setattr(sys, "argv", ["process_reports.py", str(day_dir), str(liste)])
+    with pytest.raises(FileNotFoundError) as excinfo:
+        main()
+    assert "Evening report" in str(excinfo.value)
+    assert str(day_dir) in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Raise clear `FileNotFoundError` when morning or evening report files are missing
- Add regression tests covering absent morning/evening reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed3d6a5288330b60dde06b42e09fe