### PR TITLE
Refactor month sheet computation with MONTH_MAP

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -263,7 +263,6 @@ def main():
 
     day_str = f"{args.day_dir.name}.2025"
     day = dt.datetime.strptime(day_str, "%d.%m.%Y").date()
-    month_sheet = day.strftime("%B_%y").capitalize()
     month_sheet = f"{MONTH_MAP[day.month]}_{day.strftime('%y')}"
 
     # Read existing technician names to aid fuzzy matching


### PR DESCRIPTION
## Summary
- compute `month_sheet` only once using `MONTH_MAP` for German month names

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed3d7e3408330af5c2b99fd602292