### PR TITLE
Derive report year dynamically

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -277,7 +277,20 @@ def main():
     parser.add_argument("liste", type=Path, help="Path to Liste.xlsx")
     args = parser.parse_args()
 
-    day_str = f"{args.day_dir.name}.2025"
+    # Determine year from parent directory (e.g. ``Juli_25`` -> 2025)
+    # or fall back to the current system year.
+    parent = args.day_dir.parent.name
+    year_part = None
+    if "_" in parent:
+        suffix = parent.rsplit("_", 1)[-1]
+        if suffix.isdigit():
+            year_part = int(suffix)
+            if year_part < 100:
+                year_part += 2000
+    if year_part is None:
+        year_part = dt.date.today().year
+
+    day_str = f"{args.day_dir.name}.{year_part}"
     day = dt.datetime.strptime(day_str, "%d.%m.%Y").date()
     month_sheet = f"{MONTH_MAP[day.month]}_{day.strftime('%y')}"
 

--- a/tests/test_main_year_from_parent.py
+++ b/tests/test_main_year_from_parent.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import datetime as dt
+
+import pytest
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from process_reports import main
+
+
+def create_liste(path: Path, sheet: str) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = sheet
+    wb.save(path)
+
+
+def test_main_uses_year_from_parent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    base_dir = tmp_path / "Juli_26"
+    day_dir = base_dir / "01.07"
+    day_dir.mkdir(parents=True)
+
+    liste = tmp_path / "Liste.xlsx"
+    create_liste(liste, "Juli_26")
+
+    # Create dummy morning and evening files
+    wb = Workbook()
+    wb.save(day_dir / "morning7.xlsx")
+    wb.save(day_dir / "evening19.xlsx")
+
+    def fake_load_calls(path, valid_names=None):
+        return dt.date(2026, 7, 1), {}
+
+    called = {}
+
+    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary, evening_summary):
+        called["month_sheet"] = month_sheet
+        called["target_date"] = target_date
+
+    monkeypatch.setattr(sys, "argv", ["process_reports.py", str(day_dir), str(liste)])
+    monkeypatch.setattr("process_reports.load_calls", fake_load_calls)
+    monkeypatch.setattr("process_reports.update_liste", fake_update_liste)
+
+    main()
+
+    assert called["month_sheet"] == "Juli_26"
+    assert called["target_date"] == dt.date(2026, 7, 1)


### PR DESCRIPTION
## Summary
- remove hard-coded 2025 in `process_reports.main`
- infer year from parent directory or system time
- add test covering `Juli_26` year parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688edcb18f7c8330818462b4643d0835