### PR TITLE
Limit openpyxl warning filters to safe loader and test

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -36,17 +36,11 @@ try:
 except Exception as exc:  # pragma: no cover - missing dependency
     raise SystemExit("openpyxl is required: {}".format(exc))
 
-# Suppress noisy openpyxl warnings about missing styles and unsupported features
-warnings.filterwarnings(
-    "ignore",
-    message="Workbook contains no default style, apply openpyxl's default",
-    category=UserWarning,
-)
-warnings.filterwarnings(
-    "ignore",
-    message="Data Validation extension is not supported and will be removed",
-    category=UserWarning,
-)
+# Known noisy openpyxl warnings to suppress when loading workbooks.
+OPENPYXL_WARNINGS = [
+    "Workbook contains no default style, apply openpyxl's default",
+    "Data Validation extension is not supported and will be removed",
+]
 
 
 def safe_load_workbook(filename: Path | str, *args, **kwargs):
@@ -65,16 +59,8 @@ def safe_load_workbook(filename: Path | str, *args, **kwargs):
         raise FileNotFoundError(f"Workbook not found: {path}")
 
     with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            message="Workbook contains no default style, apply openpyxl's default",
-            category=UserWarning,
-        )
-        warnings.filterwarnings(
-            "ignore",
-            message="Data Validation extension is not supported and will be removed",
-            category=UserWarning,
-        )
+        for msg in OPENPYXL_WARNINGS:
+            warnings.filterwarnings("ignore", message=msg, category=UserWarning)
         return load_workbook(path, *args, **kwargs)
 
 

--- a/tests/test_safe_load_workbook.py
+++ b/tests/test_safe_load_workbook.py
@@ -1,0 +1,21 @@
+import warnings
+from pathlib import Path
+import pytest
+import process_reports
+
+@pytest.mark.parametrize("message", process_reports.OPENPYXL_WARNINGS)
+def test_safe_load_workbook_suppresses_openpyxl_warnings(tmp_path, monkeypatch, message):
+    dummy = tmp_path / "dummy.xlsx"
+    dummy.write_text("dummy")
+
+    def fake_load_workbook(filename, *args, **kwargs):
+        warnings.warn(message, UserWarning)
+        return object()
+
+    monkeypatch.setattr(process_reports, "load_workbook", fake_load_workbook)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = process_reports.safe_load_workbook(dummy)
+    assert not caught
+    assert result is not None


### PR DESCRIPTION
## Summary
- drop global `warnings.filterwarnings` in favor of localized suppression in `safe_load_workbook`
- parameterized test ensures `safe_load_workbook` emits no noisy openpyxl warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688edcb50be883308091b05166fdca2d