### PR TITLE
Add monthly technician analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ The command expects the directory for the day (e.g. `Juli_25/01.07`) and the
 path to the master workbook (`Liste.xlsx`).  The script requires
 [openpyxl](https://openpyxl.readthedocs.io/) to be installed.
 
+To analyse a full month and report technicians without calls or belonging to
+another region, run:
+
+```bash
+python analyze_month.py Juli_25 Liste.xlsx --output report.csv
+```
+
+This writes a CSV file with the categories `no_calls` and `region_mismatch` for
+each technician.
+
 ## Troubleshooting
 
 ### Empty summaries

--- a/analyze_month.py
+++ b/analyze_month.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from process_reports import load_calls, safe_load_workbook
+
+
+def _read_names_from_liste(liste: Path, sheet: str) -> list[str]:
+    """Return technician names from column A of *sheet* in *liste*."""
+    wb = safe_load_workbook(liste, read_only=True)
+    try:
+        if sheet not in wb.sheetnames:
+            raise KeyError(f"Worksheet {sheet} does not exist in {liste}")
+        ws = wb[sheet]
+        return [
+            str(ws.cell(row=r, column=1).value).strip()
+            for r in range(2, ws.max_row + 1)
+            if ws.cell(row=r, column=1).value
+        ]
+    finally:
+        wb.close()
+
+
+def analyze_month(month_dir: Path, liste: Path, output: Path) -> None:
+    """Analyse all day folders inside *month_dir* and write summary to CSV."""
+    month_sheet = month_dir.name
+    valid_names = _read_names_from_liste(liste, month_sheet)
+    expected = set(valid_names)
+    found: set[str] = set()
+
+    for day in sorted(p for p in month_dir.iterdir() if p.is_dir()):
+        morning_files = list(day.glob("*7*.xlsx"))
+        if morning_files:
+            _, morning = load_calls(morning_files[0], valid_names)
+            found.update(morning)
+        evening_files = list(day.glob("*19*.xlsx"))
+        if evening_files:
+            _, evening = load_calls(evening_files[0], valid_names)
+            found.update(evening)
+
+    missing_calls = sorted(expected - found)
+    regional_mismatch = sorted(found - expected)
+
+    with output.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["category", "technician"])
+        for name in missing_calls:
+            writer.writerow(["no_calls", name])
+        for name in regional_mismatch:
+            writer.writerow(["region_mismatch", name])
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Analyse monthly reports")
+    parser.add_argument("month_dir", type=Path, help="Directory containing day folders")
+    parser.add_argument("liste", type=Path, help="Path to Liste.xlsx")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("analysis.csv"),
+        help="Output CSV file",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    analyze_month(args.month_dir, args.liste, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_analyze_month.py
+++ b/tests/test_analyze_month.py
@@ -1,0 +1,59 @@
+import csv
+import datetime as dt
+from pathlib import Path
+import sys
+
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from analyze_month import analyze_month
+
+
+def _create_report(path: Path, names: list[str]) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws["A2"] = dt.datetime(2025, 7, 1)
+    ws["A5"] = "Employee ID"
+    ws["B5"] = "Employee Name"
+    ws["C5"] = "Open Date Time"
+    row = 6
+    for name in names:
+        ws.cell(row=row, column=1).value = 1
+        ws.cell(row=row, column=2).value = name
+        ws.cell(row=row, column=3).value = dt.datetime(2025, 6, 30)
+        row += 1
+    wb.save(path)
+
+
+def test_analyze_month_detects_missing_and_extra(tmp_path):
+    month_dir = tmp_path / "Foo_25"
+    month_dir.mkdir()
+
+    day1 = month_dir / "01.07"
+    day1.mkdir()
+    _create_report(day1 / "m7.xlsx", ["Alice"])
+    _create_report(day1 / "e19.xlsx", ["Alice"])
+
+    day2 = month_dir / "02.07"
+    day2.mkdir()
+    _create_report(day2 / "m7.xlsx", ["Charlie"])
+    _create_report(day2 / "e19.xlsx", [])
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Foo_25"
+    ws["A1"] = "name"
+    ws["A2"] = "Alice"
+    ws["A3"] = "Bob"
+    liste_path = tmp_path / "Liste.xlsx"
+    wb.save(liste_path)
+
+    out_csv = tmp_path / "out.csv"
+    analyze_month(month_dir, liste_path, out_csv)
+
+    with out_csv.open() as fh:
+        rows = list(csv.reader(fh))
+
+    assert rows[0] == ["category", "technician"]
+    assert ["no_calls", "Bob"] in rows[1:]
+    assert ["region_mismatch", "Charlie"] in rows[1:]


### PR DESCRIPTION
## Summary
- add `analyze_month.py` to scan day folders for call activity and highlight missing or unexpected technicians
- document monthly analysis usage in README
- cover new functionality with tests

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_688edcb82c088330aa51557fd266d70c