### PR TITLE
Remove explicit workbook close

### DIFF
--- a/process_reports.py
+++ b/process_reports.py
@@ -181,8 +181,6 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
                 data["new"] += 1
             else:
                 data["old"] += 1
-        # Explicitly close workbook to avoid leaking file handles
-        wb.close()
         return target_date, summary
 
 


### PR DESCRIPTION
## Summary
- Rely on the `closing` context manager to close workbooks in `load_calls`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ee5bd8cb48330b829d9437a327d79