### PR TITLE
Handle missing openpyxl gracefully

### DIFF
--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -33,10 +33,10 @@ import warnings
 from contextlib import closing
 from .name_aliases import canonical_name
 
-try:
+try:  # pragma: no cover - import guard
     from openpyxl import load_workbook
-except Exception as exc:  # pragma: no cover - missing dependency
-    raise SystemExit("openpyxl is required: {}".format(exc))
+except Exception:  # pragma: no cover - missing dependency
+    load_workbook = None  # type: ignore[assignment]
 
 # Known noisy openpyxl warnings to suppress when loading workbooks.
 OPENPYXL_WARNINGS = [
@@ -59,6 +59,9 @@ def safe_load_workbook(filename: Path | str, *args, **kwargs):
     path = Path(filename)
     if not path.exists():
         raise FileNotFoundError(f"Workbook not found: {path}")
+
+    if load_workbook is None:
+        raise RuntimeError("openpyxl is required to load workbooks")
 
     with warnings.catch_warnings():
         for msg in OPENPYXL_WARNINGS:

--- a/tests/test_safe_load_workbook.py
+++ b/tests/test_safe_load_workbook.py
@@ -19,3 +19,11 @@ def test_safe_load_workbook_suppresses_openpyxl_warnings(tmp_path, monkeypatch, 
         result = process_reports.safe_load_workbook(dummy)
     assert not caught
     assert result is not None
+
+
+def test_safe_load_workbook_requires_openpyxl(tmp_path, monkeypatch):
+    dummy = tmp_path / "dummy.xlsx"
+    dummy.write_text("dummy")
+    monkeypatch.setattr(process_reports, "load_workbook", None)
+    with pytest.raises(RuntimeError, match="openpyxl is required"):
+        process_reports.safe_load_workbook(dummy)


### PR DESCRIPTION
## Summary
- defer importing openpyxl and raise a clear runtime error when it's unavailable
- add test coverage for missing openpyxl handling in safe_load_workbook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eec15db58833082fe14b31e747b10