### PR TITLE
Add interactive technician assignment GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,14 @@ file if logging is redirected.
 ``dispatch.process_reports.load_calls`` compares reported names to those already
 listed in ``Liste.xlsx``. When a technician cannot be matched, the function
 emits a warning so unassigned calls are easy to spot during processing.
+
+### Manual assignment
+
+To interactively map unrecognized technician names to known ones, run the Tk GUI:
+
+```bash
+python assign_gui.py data/Juli_25 --liste data/Liste.xlsx
+```
+
+Unknown names appear on the left and can be dragged onto the list of valid technicians.  Press **Export** to print the chosen mappings.
+

--- a/assign_gui.py
+++ b/assign_gui.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+import tkinter as tk
+from tkinter import ttk
+
+from dispatch.aggregate_warnings import gather_valid_names, aggregate_warnings
+
+
+class AssignmentApp(tk.Tk):
+    """Simple drag-and-drop GUI to map unknown names to known technicians."""
+
+    def __init__(self, unknown: Counter[str], valid: list[str]) -> None:
+        super().__init__()
+        self.title("Techniker-Zuordnung")
+
+        self._drag_item: str | None = None
+        self.mappings: dict[str, str] = {}
+
+        # Unknown names list
+        left = ttk.Frame(self)
+        left.pack(side="left", fill="both", expand=True, padx=10, pady=10)
+        ttk.Label(left, text="Unbekannte Namen").pack()
+        self.unknown = tk.Listbox(left)
+        self.unknown.pack(fill="both", expand=True)
+        for name, count in unknown.items():
+            self.unknown.insert("end", f"{name} ({count})")
+        self.unknown.bind("<ButtonPress-1>", self._start_drag)
+
+        # Known names list
+        middle = ttk.Frame(self)
+        middle.pack(side="left", fill="both", expand=True, padx=10, pady=10)
+        ttk.Label(middle, text="Bekannte Techniker").pack()
+        self.valid = tk.Listbox(middle)
+        self.valid.pack(fill="both", expand=True)
+        for name in valid:
+            self.valid.insert("end", name)
+        self.valid.bind("<ButtonRelease-1>", self._on_drop)
+
+        # Mappings display
+        right = ttk.Frame(self)
+        right.pack(side="left", fill="both", expand=True, padx=10, pady=10)
+        ttk.Label(right, text="Zuordnungen").pack()
+        self.result = tk.Listbox(right)
+        self.result.pack(fill="both", expand=True)
+
+        ttk.Button(self, text="Export", command=self._export).pack(side="bottom", pady=5)
+
+    def _start_drag(self, event: tk.Event) -> None:
+        index = self.unknown.nearest(event.y)
+        if index >= 0:
+            self._drag_item = self.unknown.get(index)
+
+    def _on_drop(self, event: tk.Event) -> None:
+        if not self._drag_item:
+            return
+        unknown_name = self._drag_item.split(" (", 1)[0]
+        index = self.valid.nearest(event.y)
+        if index >= 0:
+            known_name = self.valid.get(index)
+            self.mappings[unknown_name] = known_name
+            self.result.insert("end", f"{unknown_name} -> {known_name}")
+            # remove from unknown list
+            items = self.unknown.get(0, "end")
+            self.unknown.delete(0, "end")
+            for item in items:
+                if not item.startswith(unknown_name + " "):
+                    self.unknown.insert("end", item)
+        self._drag_item = None
+
+    def _export(self) -> None:
+        for unknown, known in self.mappings.items():
+            print(f"{unknown},{known}")
+        self.destroy()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Interaktive Zuordnung unbekannter Techniker")
+    parser.add_argument("report_dir", type=Path, help="Verzeichnis mit Tagesberichten")
+    parser.add_argument("--liste", type=Path, default=Path("Liste.xlsx"), help="Pfad zur Liste.xlsx")
+    args = parser.parse_args(argv)
+
+    valid = gather_valid_names(args.liste)
+    unknown = aggregate_warnings(args.report_dir, valid)
+
+    app = AssignmentApp(unknown, valid)
+    app.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - GUI entry point
+    main()


### PR DESCRIPTION
## Summary
- add Tkinter GUI to assign unknown technician names via drag and drop
- document new `assign_gui.py` helper in README

## Testing
- `pip install openpyxl`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eee16486c833089125992a27f54dc