### PR TITLE
feat: provide default paths for GUI

### DIFF
--- a/assign_gui.py
+++ b/assign_gui.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import ttk
 
-from dispatch.aggregate_warnings import gather_valid_names, aggregate_warnings
+from dispatch.aggregate_warnings import aggregate_warnings, gather_valid_names
 
 
 class AssignmentApp(tk.Tk):
@@ -77,9 +77,23 @@ class AssignmentApp(tk.Tk):
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Interaktive Zuordnung unbekannter Techniker")
-    parser.add_argument("report_dir", type=Path, help="Verzeichnis mit Tagesberichten")
-    parser.add_argument("--liste", type=Path, default=Path("Liste.xlsx"), help="Pfad zur Liste.xlsx")
+    base_dir = Path(__file__).resolve().parent
+    parser = argparse.ArgumentParser(
+        description="Interaktive Zuordnung unbekannter Techniker"
+    )
+    parser.add_argument(
+        "report_dir",
+        nargs="?",
+        type=Path,
+        default=base_dir / "data",
+        help="Verzeichnis mit Tagesberichten",
+    )
+    parser.add_argument(
+        "--liste",
+        type=Path,
+        default=base_dir / "data" / "Liste.xlsx",
+        help="Pfad zur Liste.xlsx",
+    )
     args = parser.parse_args(argv)
 
     valid = gather_valid_names(args.liste)


### PR DESCRIPTION
## Summary
- allow `assign_gui` to run without command line arguments by providing default paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef346a1048330af5f6edc71d70d62