### PR TITLE
feat: provide default paths for GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ emits a warning so unassigned calls are easy to spot during processing.
 To interactively map unrecognized technician names to known ones, run the Tk GUI:
 
 ```bash
-python assign_gui.py data/Juli_25 --liste data/Liste.xlsx
+python assign_gui.py  # uses data/ and Liste.xlsx by default
 ```
+
+On Windows, the `assign_gui.bat` helper allows starting the GUI by double-clicking the file.
 
 Unknown names appear on the left and can be dragged onto the list of valid technicians.  Press **Export** to print the chosen mappings.
 

--- a/assign_gui.bat
+++ b/assign_gui.bat
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0assign_gui.py" %*

--- a/assign_gui.py
+++ b/assign_gui.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import annotations
 
 import argparse
@@ -6,7 +7,7 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import ttk
 
-from dispatch.aggregate_warnings import gather_valid_names, aggregate_warnings
+from dispatch.aggregate_warnings import aggregate_warnings, gather_valid_names
 
 
 class AssignmentApp(tk.Tk):
@@ -77,13 +78,32 @@ class AssignmentApp(tk.Tk):
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Interaktive Zuordnung unbekannter Techniker")
-    parser.add_argument("report_dir", type=Path, help="Verzeichnis mit Tagesberichten")
-    parser.add_argument("--liste", type=Path, default=Path("Liste.xlsx"), help="Pfad zur Liste.xlsx")
+    base_dir = Path(__file__).resolve().parent
+    parser = argparse.ArgumentParser(
+        description="Interaktive Zuordnung unbekannter Techniker"
+    )
+    parser.add_argument(
+        "report_dir",
+        nargs="?",
+        type=Path,
+        default=base_dir / "data",
+        help="Verzeichnis mit Tagesberichten",
+    )
+    parser.add_argument(
+        "--liste",
+        type=Path,
+        default=base_dir / "data" / "Liste.xlsx",
+        help="Pfad zur Liste.xlsx",
+    )
     args = parser.parse_args(argv)
 
-    valid = gather_valid_names(args.liste)
-    unknown = aggregate_warnings(args.report_dir, valid)
+    try:
+        valid = gather_valid_names(args.liste)
+        unknown = aggregate_warnings(args.report_dir, valid)
+    except RuntimeError as exc:  # missing dependency like openpyxl
+        print(exc)
+        print("Install required dependencies with: pip install openpyxl")
+        return
 
     app = AssignmentApp(unknown, valid)
     app.mainloop()


### PR DESCRIPTION
## Summary
- allow `assign_gui` to run without command line arguments by providing default paths
- add helpful error message and Windows launcher for easier GUI startup
- document default invocation and batch helper in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef346a1048330af5f6edc71d70d62