### PR TITLE
Keep assign_gui window open and skip malformed reports

### DIFF
--- a/assign_gui.bat
+++ b/assign_gui.bat
@@ -1,2 +1,3 @@
 @echo off
 python "%~dp0assign_gui.py" %*
+pause

--- a/dispatch/aggregate_warnings.py
+++ b/dispatch/aggregate_warnings.py
@@ -57,7 +57,11 @@ def aggregate_warnings(report_dir: Path, valid_names: list[str]) -> Counter[str]
         for file in sorted(report_dir.rglob("*.xlsx")):
             stream.seek(0)
             stream.truncate(0)
-            load_calls(file, valid_names)
+            try:
+                load_calls(file, valid_names)
+            except ValueError as exc:
+                print(f"{file}: {exc}")
+                continue
             stream.seek(0)
             for line in stream.read().splitlines():
                 match = re.search(r"'([^']+)'", line)


### PR DESCRIPTION
## Summary
- ensure Windows helper keeps its command window open after running the GUI
- skip Excel reports missing a header row instead of crashing `aggregate_warnings`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ef686aa048330b59d6ace1f45b783