### PR TITLE
Skip Liste workbook in aggregate warnings

### DIFF
--- a/dispatch/aggregate_warnings.py
+++ b/dispatch/aggregate_warnings.py
@@ -55,6 +55,8 @@ def aggregate_warnings(report_dir: Path, valid_names: list[str]) -> Counter[str]
     root_logger.setLevel(logging.WARNING)
     try:
         for file in sorted(report_dir.rglob("*.xlsx")):
+            if file.name.lower().startswith("liste"):
+                continue  # skip the aggregated Liste workbook
             stream.seek(0)
             stream.truncate(0)
             try:

--- a/tests/test_aggregate_warnings.py
+++ b/tests/test_aggregate_warnings.py
@@ -1,0 +1,20 @@
+from collections import Counter
+from pathlib import Path
+import sys
+
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from dispatch.aggregate_warnings import aggregate_warnings
+
+
+def test_aggregate_warnings_skips_liste(tmp_path, capsys):
+    wb = Workbook()
+    wb.save(tmp_path / "Liste.xlsx")
+    wb.save(tmp_path / "Liste_copy.xlsx")
+    wb.close()
+
+    result = aggregate_warnings(tmp_path, [])
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert result == Counter()


### PR DESCRIPTION
## Summary
- ignore `Liste*.xlsx` files when aggregating warnings to avoid header row errors
- add regression test ensuring `aggregate_warnings` skips the `Liste` workbook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef903da108330aff64d56cfa6826e