### PR TITLE
Warn on unknown technicians in call reports

### DIFF
--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -176,6 +176,8 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
                 continue
             tech_raw = str(row[name_idx]).strip()
             tech = canonical_name(tech_raw, valid_names or [])
+            if valid_names and tech not in valid_names:
+                logging.warning("Unknown technician '%s' in %s", tech_raw, path)
 
             open_date = excel_to_date(row[open_idx])
             data = summary.setdefault(tech, {"total": 0, "new": 0, "old": 0})

--- a/tests/test_aggregate_warnings.py
+++ b/tests/test_aggregate_warnings.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from pathlib import Path
 import sys
+import datetime as dt
 
 from openpyxl import Workbook
 
@@ -18,3 +19,21 @@ def test_aggregate_warnings_skips_liste(tmp_path, capsys):
     captured = capsys.readouterr()
     assert captured.out == ""
     assert result == Counter()
+
+
+def test_aggregate_warnings_counts_unknown_names(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Report"
+    ws["A2"] = dt.datetime(2025, 7, 1)
+    ws["A5"] = "Employee ID"
+    ws["B5"] = "Employee Name"
+    ws["C5"] = "Open Date Time"
+    ws["A6"] = 1
+    ws["B6"] = "Bob"
+    ws["C6"] = dt.datetime(2025, 6, 30)
+    wb.save(tmp_path / "report.xlsx")
+    wb.close()
+
+    result = aggregate_warnings(tmp_path, ["Alice"])
+    assert result == Counter({"Bob": 1})


### PR DESCRIPTION
## Summary
- log a warning when a technician name isn't in the expected list
- test that `aggregate_warnings` counts unknown technicians

## Testing
- `pytest -q`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_688f5ab795ac83308c5a3739d354bfd5