### PR TITLE
Improve export error handling in GUI

### DIFF
--- a/assign_gui.py
+++ b/assign_gui.py
@@ -82,6 +82,7 @@ class AssignmentApp(tk.Tk):
 
         try:
             from openpyxl import load_workbook  # type: ignore
+            from openpyxl.utils.exceptions import InvalidFileException  # type: ignore
 
             wb = load_workbook(self.liste_path)
             sheet_name = "Zuordnungen"
@@ -95,8 +96,13 @@ class AssignmentApp(tk.Tk):
             wb.save(self.liste_path)
             wb.close()
             print(f"Liste aktualisiert: {self.liste_path}")
+        except ImportError:
+            print("Konnte Liste.xlsx nicht aktualisieren: openpyxl ist nicht installiert")
+        except InvalidFileException as exc:
+            print(f"Konnte Liste.xlsx nicht aktualisieren: {exc}")
         except Exception as exc:
             print(f"Konnte Liste.xlsx nicht aktualisieren: {exc}")
+            raise
 
         self.destroy()
 

--- a/tests/test_assign_gui_export.py
+++ b/tests/test_assign_gui_export.py
@@ -1,0 +1,28 @@
+import types
+from pathlib import Path
+import sys
+import pytest
+import openpyxl
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import assign_gui
+
+
+def test_export_reraises_unexpected(tmp_path, monkeypatch, capsys):
+    dummy = types.SimpleNamespace(
+        mappings={"foo": "bar"},
+        liste_path=tmp_path / "Liste.xlsx",
+        destroy=lambda: None,
+    )
+    monkeypatch.setattr(assign_gui, "__file__", str(tmp_path / "assign_gui.py"))
+
+    def boom(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(openpyxl, "load_workbook", boom)
+
+    with pytest.raises(ValueError, match="boom"):
+        assign_gui.AssignmentApp._export(dummy)
+
+    out = capsys.readouterr().out
+    assert "Konnte Liste.xlsx nicht aktualisieren: boom" in out


### PR DESCRIPTION
## Summary
- Handle openpyxl import errors and invalid workbooks explicitly in assignment GUI export.
- Re-raise unexpected export errors so failures are visible.
- Add regression test ensuring export re-raises unexpected errors.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f61089a5883308a78a33c1136dc00