### PR TITLE
Add session summary

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -1,0 +1,12 @@
+# Session Summary
+
+We have not yet identified a solution. This file captures progress so we can continue from here in future sessions.
+
+## Progress
+- Installed `openpyxl` dependency.
+- Ran `pytest -q` with all tests passing (19 passed).
+
+## Next Steps
+- Clarify the desired solution.
+- Explore relevant repository components.
+


### PR DESCRIPTION
## Summary
- Add a session summary file to track progress and outline next steps.
- Document dependency installation and passing test run.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6c17ab2483308519d3dd1e87ecf3