### PR TITLE
Add monthly processing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ The command expects the directory for the day (e.g. ``data/Juli_25/01.07``) and
 the path to the master workbook (``data/Liste.xlsx``).  The script requires
 [openpyxl](https://openpyxl.readthedocs.io/) to be installed.
 
+To process all days of a month in one run, use:
+
+```bash
+python main.py process-month data/Juli_25 data/Liste.xlsx
+```
+
+The command iterates over all subdirectories in ``data/Juli_25`` and processes
+each day that contains matching ``*7*.xlsx`` and ``*19*.xlsx`` files.
+
 To analyse a full month and report technicians without calls or belonging to
 another region, run:
 

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -270,6 +270,30 @@ def update_liste(
         wb.close()
 
 
+def process_month(month_dir: Path, liste: Path) -> None:
+    """Process all day report directories within ``month_dir``.
+
+    Each subdirectory is expected to contain a morning (``*7*.xlsx``) and an
+    evening (``*19*.xlsx``) report. Directories missing either file are skipped
+    with a warning.
+    """
+
+    for day_dir in sorted(p for p in month_dir.iterdir() if p.is_dir()):
+        morning = list(day_dir.glob("*7*.xlsx"))
+        evening = list(day_dir.glob("*19*.xlsx"))
+        if not morning or not evening:
+            missing: list[str] = []
+            if not morning:
+                missing.append("*7*.xlsx")
+            if not evening:
+                missing.append("*19*.xlsx")
+            logger.warning(
+                "Skipping %s: missing %s", day_dir, " and ".join(missing)
+            )
+            continue
+        main([str(day_dir), str(liste)])
+
+
 def main(argv: Iterable[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Process dispatch reports")
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -14,6 +14,10 @@ def main(argv: list[str] | None = None) -> None:
     p_process.add_argument("day_dir", type=Path, help="Directory containing daily reports")
     p_process.add_argument("liste", type=Path, help="Path to Liste.xlsx")
 
+    p_process_month = sub.add_parser("process-month", help="Process all day reports in a month")
+    p_process_month.add_argument("month_dir", type=Path, help="Directory containing day folders")
+    p_process_month.add_argument("liste", type=Path, help="Path to Liste.xlsx")
+
     p_analyze = sub.add_parser("analyze", help="Analyse a month of reports")
     p_analyze.add_argument("month_dir", type=Path, help="Directory containing day folders")
     p_analyze.add_argument("liste", type=Path, help="Path to Liste.xlsx")
@@ -27,6 +31,8 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "process":
         process_reports.main([str(args.day_dir), str(args.liste)])
+    elif args.command == "process-month":
+        process_reports.process_month(args.month_dir, args.liste)
     elif args.command == "analyze":
         analyze_month.main([str(args.month_dir), str(args.liste), "-o", str(args.output)])
     elif args.command == "warnings":

--- a/tests/test_main_process_month_cli.py
+++ b/tests/test_main_process_month_cli.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from main import main as cli_main
+
+
+def test_cli_process_month(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    month_dir = tmp_path / "Juli_25"
+    liste = tmp_path / "Liste.xlsx"
+
+    called: dict[str, Path] = {}
+
+    def fake_process_month(m_dir, liste_path):
+        called["month_dir"] = m_dir
+        called["liste"] = liste_path
+
+    monkeypatch.setattr("dispatch.process_reports.process_month", fake_process_month)
+
+    cli_main(["process-month", str(month_dir), str(liste)])
+
+    assert called["month_dir"] == month_dir
+    assert called["liste"] == liste

--- a/tests/test_process_month.py
+++ b/tests/test_process_month.py
@@ -1,0 +1,56 @@
+import datetime as dt
+import sys
+from pathlib import Path
+import logging
+
+import pytest
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from dispatch.process_reports import process_month
+
+
+def create_liste(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    wb.save(path)
+
+
+def test_process_month_multiple_days(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    month_dir = tmp_path / "Juli_25"
+    day1 = month_dir / "01.07"
+    day2 = month_dir / "02.07"
+    missing = month_dir / "03.07"
+    for d in (day1, day2, missing):
+        d.mkdir(parents=True)
+
+    wb = Workbook()
+    wb.save(day1 / "m7.xlsx")
+    wb.save(day1 / "e19.xlsx")
+    wb = Workbook()
+    wb.save(day2 / "m7.xlsx")
+    wb.save(day2 / "e19.xlsx")
+    wb = Workbook()
+    wb.save(missing / "m7.xlsx")  # only morning file to trigger warning
+
+    liste = tmp_path / "Liste.xlsx"
+    create_liste(liste)
+
+    def fake_load_calls(path, valid_names=None):
+        day = int(Path(path).parent.name.split(".")[0])
+        return dt.date(2025, 7, day), {}
+
+    calls: list[dt.date] = []
+
+    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary, evening_summary):
+        calls.append(target_date)
+
+    monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
+    monkeypatch.setattr("dispatch.process_reports.update_liste", fake_update_liste)
+
+    with caplog.at_level(logging.WARNING):
+        process_month(month_dir, liste)
+
+    assert calls == [dt.date(2025, 7, 1), dt.date(2025, 7, 2)]
+    assert "missing *19*.xlsx" in caplog.text


### PR DESCRIPTION
## Summary
- add `process-month` CLI subcommand to process all day folders in a month
- implement `process_month` helper that iterates through day directories and logs missing report files
- document new command and add tests for monthly processing and CLI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f7c2ae2cc8330a12e989811c9ff5d