### PR TITLE
Document warnings subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ python main.py analyze data/Juli_25 data/Liste.xlsx --output report.csv
 This writes a CSV file with the categories ``no_calls`` and ``region_mismatch``
 for each technician.
 
+To collect unknown technician names across multiple reports and count how often
+they appear, use the ``warnings`` subcommand:
+
+```bash
+python main.py warnings data/Juli_25 --liste data/Liste.xlsx
+```
+
+This command scans all reports below ``data/Juli_25`` and prints a summary of
+unresolved names to help maintain the alias list.  Use the output to extend the
+``ALIASES`` mapping in ``dispatch/name_aliases.py`` so future runs recognise
+these variants.
+
 ## Generated files
 
 The project may produce CSV outputs such as `analysis.csv` and `techniker_export.csv`. These files are generated at runtime and are not checked into version control.


### PR DESCRIPTION
## Summary
- document `main.py warnings` helper for collecting unresolved technician names
- note where to extend the alias list after running the command

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f92112a30833089b5658b94a8dafd