### PR TITLE
Improve Excel updates and CLI, German README

### DIFF
--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -15,9 +15,11 @@ corresponding month. The workbook contains weekly column blocks consisting of
     name, date, weekday, pudo, pickup time, valid, info, pre-closed,
     total calls, old calls, new calls, details, mails
 
-Blocks are repeated for each week and separated by an empty column.  The first
-block starts at column ``A``.  To update values for a given date ``d`` the
-block index is ``(d.day-1)//7`` and the starting column is ``1 + index*14``.
+Blocks are repeated for each week and separated by an empty column. Each day
+occupies its own 13-column block and weeks consist of seven such blocks.
+The first block starts at column ``A``.  For a date ``d`` the week index is
+``(d.day-1)//7`` and the day index within the week is ``(d.day-1)%7``.  The
+starting column is therefore ``1 + week_index*14*7 + day_index*14``.
 
 The script requires :mod:`openpyxl` for reading and writing Excel files.
 """
@@ -170,6 +172,7 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
         prev_day = prev_business_day(target_date)
 
         summary: Dict[str, Dict[str, int]] = {}
+        unknown: set[str] = set()
         for row in ws.iter_rows(min_row=header_row_idx + 1, values_only=True):
             if row and any(
                 _norm(cell) == marker_norm for cell in row if isinstance(cell, str)
@@ -180,7 +183,7 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
             tech_raw = str(row[name_idx]).strip()
             tech = canonical_name(tech_raw, valid_names or [])
             if valid_names and tech not in valid_names:
-                logger.warning("Unknown technician '%s' in %s", tech_raw, path)
+                unknown.add(tech_raw)
 
             open_date = excel_to_date(row[open_idx])
             data = summary.setdefault(tech, {"total": 0, "new": 0, "old": 0})
@@ -189,6 +192,8 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
                 data["new"] += 1
             else:
                 data["old"] += 1
+        for name in sorted(unknown):
+            logger.warning("Unknown technician '%s' in %s", name, path)
         return target_date, summary
 
 
@@ -232,8 +237,15 @@ def update_liste(
         morning = canonicalize_summary(morning)
         evening = canonicalize_summary(evening)
 
+        # Determine the start column for the given date.  ``Liste.xlsx`` stores
+        # daily values in blocks of 13 columns, separated by an empty column.
+        # Seven such blocks form a week.  The previous implementation only
+        # considered the week index which caused all days of the same week to
+        # overwrite each other.  We now also offset by the weekday inside the
+        # week so each day has its own column range.
         week_index = (day.day - 1) // 7
-        start_col = 1 + week_index * 14
+        day_index = (day.day - 1) % 7
+        start_col = 1 + week_index * 14 * 7 + day_index * 14
         remaining = set(morning)
 
         for row in range(2, ws.max_row + 1):
@@ -271,10 +283,7 @@ def update_liste(
 
 
 def process_month(month_dir: Path, liste: Path) -> None:
-    """Process all day report directories within ``month_dir``.
-
-in
-    """
+    """Process all day report directories within ``month_dir``."""
 
     for day_dir in sorted(p for p in month_dir.iterdir() if p.is_dir()):
         morning = list(day_dir.glob("*7*.xlsx"))

--- a/main.py
+++ b/main.py
@@ -27,6 +27,20 @@ def main(argv: list[str] | None = None) -> None:
     p_warnings.add_argument("report_dir", type=Path, help="Path to report directory")
     p_warnings.add_argument("--liste", type=Path, default=Path("Liste.xlsx"), help="Path to Liste.xlsx")
 
+    p_all = sub.add_parser(
+        "run-all",
+        help="Process reports for a month, analyse them and show warnings in one step",
+    )
+    p_all.add_argument("month_dir", type=Path, help="Directory containing day folders")
+    p_all.add_argument("liste", type=Path, help="Path to Liste.xlsx")
+    p_all.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("analysis.csv"),
+        help="Output CSV file for analysis",
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "process":
@@ -37,6 +51,10 @@ def main(argv: list[str] | None = None) -> None:
         analyze_month.main([str(args.month_dir), str(args.liste), "-o", str(args.output)])
     elif args.command == "warnings":
         aggregate_warnings.main([str(args.report_dir), "--liste", str(args.liste)])
+    elif args.command == "run-all":
+        process_reports.process_month(args.month_dir, args.liste)
+        analyze_month.main([str(args.month_dir), str(args.liste), "-o", str(args.output)])
+        aggregate_warnings.main([str(args.month_dir), "--liste", str(args.liste)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix column calculation so each day of a week writes to its own cells in `Liste.xlsx`
- Add `run-all` command to process, analyse and aggregate warnings in one step
- Provide German README with updated usage instructions
- Warn only once per unknown technician while processing reports
- Clean up `process_month` docstring

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f98576054833082d67eee12d5f6c3