### PR TITLE
Load technician aliases from workbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ Mit der kleinen Tk‑Oberfläche lassen sich unbekannte Namen interaktiv zuweise
 python assign_gui.py  # nutzt standardmäßig data/ und Liste.xlsx
 ```
 Das Fenster zeigt unbekannte Namen links; sie können per Drag & Drop einer bekannten Liste zugeordnet werden. Über **Export** werden die Zuordnungen ausgegeben.
+Die exportierten Zuordnungen landen in einem Arbeitsblatt "Zuordnungen" der
+``Liste.xlsx`` und werden bei späteren Verarbeitungen automatisch
+berücksichtigt.

--- a/dispatch/aggregate_warnings.py
+++ b/dispatch/aggregate_warnings.py
@@ -26,6 +26,7 @@ from typing import Iterable
 
 from . import process_reports
 from .process_reports import load_calls, safe_load_workbook
+from .name_aliases import load_aliases
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ def gather_valid_names(liste: Path) -> list[str]:
     needs.  Empty cells are ignored.
     """
 
+    load_aliases(liste)
     names: list[str] = []
     with closing(safe_load_workbook(liste, read_only=True)) as wb:
         ws = wb.active

--- a/dispatch/analyze_month.py
+++ b/dispatch/analyze_month.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Iterable
 
 from .process_reports import load_calls, safe_load_workbook
+from .name_aliases import load_aliases
 
 
 def _read_names_from_liste(liste: Path, sheet: str) -> list[str]:
@@ -26,6 +27,7 @@ def _read_names_from_liste(liste: Path, sheet: str) -> list[str]:
 
 def analyze_month(month_dir: Path, liste: Path, output: Path) -> None:
     """Analyse all day folders inside *month_dir* and write summary to CSV."""
+    load_aliases(liste)
     month_sheet = month_dir.name
     valid_names = _read_names_from_liste(liste, month_sheet)
     expected = set(valid_names)

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Tuple
 import warnings
 from contextlib import closing
-from .name_aliases import canonical_name
+from .name_aliases import canonical_name, load_aliases
 
 
 logger = logging.getLogger(__name__)
@@ -306,6 +306,11 @@ def main(argv: Iterable[str] | None = None) -> None:
     )
     parser.add_argument("liste", type=Path, help="Path to Liste.xlsx")
     args = parser.parse_args(list(argv) if argv is not None else None)
+
+    # Load optional technician alias mappings from Liste.xlsx so that
+    # ``canonical_name`` can resolve previously assigned variants.  Missing
+    # dependencies or worksheets are ignored silently.
+    load_aliases(args.liste)
 
     # Determine year from parent directory (e.g. ``Juli_25`` -> 2025)
     # or fall back to the current system year.

--- a/tests/test_name_aliases.py
+++ b/tests/test_name_aliases.py
@@ -19,3 +19,22 @@ def test_removes_parentheses_and_surname():
 def test_falls_back_to_norm_when_no_match():
     valid = ["Daniyal"]
     assert na.canonical_name("Unknown", valid) == "Unknown"
+
+
+def test_load_aliases_from_liste(tmp_path, monkeypatch):
+    from openpyxl import Workbook
+
+    # Create Liste.xlsx with Zuordnungen sheet mapping "Bobi" -> "Bob"
+    wb = Workbook()
+    ws = wb.create_sheet("Zuordnungen")
+    ws.append(["Unbekannt", "Bekannt"])
+    ws.append(["Bobi", "Bob"])
+    wb.save(tmp_path / "Liste.xlsx")
+    wb.close()
+
+    # Start with empty aliases
+    monkeypatch.setattr(na, "ALIASES", {})
+    na.refresh_alias_map()
+
+    na.load_aliases(tmp_path / "Liste.xlsx")
+    assert na.canonical_name("bobi", ["Bob"]) == "Bob"


### PR DESCRIPTION
## Summary
- pull technician alias mappings from Liste.xlsx and apply them during processing
- document that alias assignments from assign_gui are automatically reused
- test reading alias assignments from the Zuordnungen sheet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f9f3af53c83308a832e8eae98d3ad