### PR TITLE
Automatisierte Auswertung von Techniker-Calls

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -1,0 +1,8 @@
+## 2025-08-03
+- Repository erkundet und keine AGENTS.md gefunden.
+- Datei process_calls.py mit Verarbeitung der Techniker-Reports erstellt.
+- Test tests/test_process_calls.py erstellt.
+- requirements.txt um pandas erweitert.
+- pytest ausgeführt: alle 23 Tests bestanden.
+- Änderungen in Git committet.
+- CLI-Test mit Beispielreport durchgeführt und temporäre Dateien entfernt.

--- a/process_calls.py
+++ b/process_calls.py
@@ -1,0 +1,58 @@
+import argparse
+import datetime as dt
+from pathlib import Path
+from typing import Union
+import pandas as pd
+
+
+def process_report(file_path: Union[str, Path], technician_name: str) -> pd.DataFrame:
+    """Lese einen Excel-Bericht ein und klassifiziere Calls."""
+    # Alle Reiter laden und zu einem DataFrame kombinieren
+    all_sheets = pd.read_excel(file_path, sheet_name=None)
+    df = pd.concat(all_sheets.values(), ignore_index=True)
+
+    # Prüfen, ob alle benötigten Spalten vorhanden sind
+    expected_cols = ["Techniker", "Callnr", "Erstellt"]
+    missing = [col for col in expected_cols if col not in df.columns]
+    if missing:
+        raise ValueError(f"Fehlende Spalten im Bericht: {missing}")
+
+    # Nur Callnummern behalten, die mit '17' beginnen
+    df["Callnr"] = df["Callnr"].astype(str)
+    df = df[df["Callnr"].str.startswith("17")]
+
+    # Auf den angegebenen Techniker filtern
+    df = df[df["Techniker"] == technician_name]
+
+    # Erstellungsdatum parsen (deutsches Format Tag.Monat.Jahr)
+    df["Erstellt"] = pd.to_datetime(df["Erstellt"], dayfirst=True)
+
+    # Heutiges Datum bestimmen und Status setzen
+    today = dt.datetime.now().date()
+    df["Status"] = df["Erstellt"].dt.date.apply(lambda d: "neu" if d == today else "alt")
+
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Techniker-Calls aus Berichten auslesen und klassifizieren"
+    )
+    parser.add_argument("report_file", help="Pfad zur Excel-Datei (z. B. '7 Uhr.xlsx')")
+    parser.add_argument(
+        "--techniker",
+        default="Ahmad, Daniyal (Keskin)",
+        help="Name des Technikers genau wie im Bericht",
+    )
+    parser.add_argument(
+        "--output", default="output_calls.xlsx", help="Pfad für die Ausgabedatei"
+    )
+    args = parser.parse_args()
+
+    result_df = process_report(args.report_file, args.techniker)
+    result_df.to_excel(args.output, index=False)
+    print(f"Ergebnis gespeichert: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openpyxl>=3.0
+pandas>=2.0

--- a/tests/test_process_calls.py
+++ b/tests/test_process_calls.py
@@ -1,0 +1,49 @@
+import datetime as dt
+from pathlib import Path
+import pandas as pd
+from process_calls import process_report
+
+
+def test_process_report_filters_and_classifies(tmp_path):
+    today = dt.date.today()
+    old_date = today - dt.timedelta(days=2)
+
+    data1 = pd.DataFrame(
+        {
+            "Techniker": [
+                "Ahmad, Daniyal (Keskin)",
+                "Ahmad, Daniyal (Keskin)",
+                "Andere Person",
+            ],
+            "Callnr": ["17500001", "18000001", "17500002"],
+            "Erstellt": [
+                today.strftime("%d.%m.%Y"),
+                today.strftime("%d.%m.%Y"),
+                today.strftime("%d.%m.%Y"),
+            ],
+        }
+    )
+    data2 = pd.DataFrame(
+        {
+            "Techniker": ["Ahmad, Daniyal (Keskin)", "Ahmad, Daniyal (Keskin)"],
+            "Callnr": ["17500003", "17500004"],
+            "Erstellt": [
+                old_date.strftime("%d.%m.%Y"),
+                today.strftime("%d.%m.%Y"),
+            ],
+        }
+    )
+
+    file_path = tmp_path / "report.xlsx"
+    with pd.ExcelWriter(file_path) as writer:
+        data1.to_excel(writer, index=False, sheet_name="Sheet1")
+        data2.to_excel(writer, index=False, sheet_name="Sheet2")
+
+    df = process_report(file_path, "Ahmad, Daniyal (Keskin)")
+
+    assert set(df["Callnr"]) == {"17500001", "17500003", "17500004"}
+
+    status_map = dict(zip(df["Callnr"], df["Status"]))
+    assert status_map["17500003"] == "alt"
+    assert status_map["17500001"] == "neu"
+    assert status_map["17500004"] == "neu"


### PR DESCRIPTION
## Zusammenfassung
- Neues Skript `process_calls.py` zum Einlesen aller Excel-Reiter, Filtern der Callnummern und Klassifizieren in "neu" oder "alt".
- Unit-Test `tests/test_process_calls.py` prüft Mehrblatt-Berichte und Statuslogik.
- `requirements.txt` um `pandas` erweitert.
- Arbeitsfortschritte in `logs/arbeitsprotokoll.md` dokumentiert.

## Testen
- `pytest -q`
- `python process_calls.py sample_report.xlsx --techniker "Ahmad, Daniyal (Keskin)" --output result.xlsx`


------
https://chatgpt.com/codex/tasks/task_e_688fa5b3f8a883309f5a76abd269fde6