### PR TITLE
Fehlerbehandlung für fehlende Berichte

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -7,3 +7,9 @@
 - Änderungen in Git committet.
 - CLI-Test mit Beispielreport durchgeführt und temporäre Dateien entfernt.
 
+## 2025-08-03 (später)
+- Fehlerbehandlung für fehlende Berichtsdateien in process_calls.py ergänzt.
+- tests/test_process_calls.py um fehlende Importe und Test für nicht vorhandene Datei erweitert.
+- pytest ausgeführt.
+- CLI mit Beispieldatei getestet und temporäre Dateien entfernt.
+- CLI-Aufruf mit fehlender Datei getestet, erwartete Fehlermeldung erhalten.

--- a/process_calls.py
+++ b/process_calls.py
@@ -8,6 +8,10 @@ import pandas as pd
 def process_report(file_path: Union[str, Path], technician_name: str) -> pd.DataFrame:
     """Lese einen Excel-Bericht ein und klassifiziere Calls."""
 
+    file_path = Path(file_path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Berichtsdatei nicht gefunden: {file_path}")
+
     # Alle Reiter laden und zu einem DataFrame kombinieren
     all_sheets = pd.read_excel(file_path, sheet_name=None)
     df = pd.concat(all_sheets.values(), ignore_index=True)
@@ -50,6 +54,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    try:
+        result_df = process_report(args.report_file, args.techniker)
+    except FileNotFoundError as err:
+        print(err)
+        return
 
     result_df.to_excel(args.output, index=False)
     print(f"Ergebnis gespeichert: {args.output}")

--- a/tests/test_process_calls.py
+++ b/tests/test_process_calls.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import pandas as pd
+import pytest
 
 from process_calls import process_report
 
@@ -46,3 +48,8 @@ def test_process_report_filters_and_classifies(tmp_path):
     assert status_map["17500003"] == "alt"
     assert status_map["17500001"] == "neu"
     assert status_map["17500004"] == "neu"
+
+
+def test_process_report_missing_file():
+    with pytest.raises(FileNotFoundError):
+        process_report("does_not_exist.xlsx", "Ahmad, Daniyal (Keskin)")


### PR DESCRIPTION
## Zusammenfassung
- Füge Prüfung auf fehlende Berichtsdateien in `process_report` hinzu.
- Behandle fehlende Dateien im CLI und speichere Ergebnis nur bei Erfolg.
- Ergänze Tests für fehlende Dateien und notwendige Importe.
- Aktualisiere Arbeitsprotokoll.

## Tests
- `pytest -q`
- `python process_calls.py cli_sample.xlsx --techniker "Ahmad, Daniyal (Keskin)" --output cli_result.xlsx`
- `python process_calls.py missing.xlsx --techniker "Ahmad, Daniyal (Keskin)" --output out.xlsx`


------
https://chatgpt.com/codex/tasks/task_e_688fb95e8cb4833098ee7c2473463af8