### PR TITLE
load_calls über alle Arbeitsblätter

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -2,6 +2,8 @@
 - Added `openpyxl>=3.0` to `requirements.txt` so Excel reports can be processed.
 - Installed dependencies and ran tests.
 - Verified `python main.py process data/Juni_25/02.06 data/Liste.xlsx` updated the workbook.
+- `load_calls` wertet nun alle Arbeitsblätter eines Reports aus und summiert die Technikerstatistiken.
+- Namensauflösung verbessert: Einträge wie `"Nachname, Vorname (Team)"` werden nun zu `"Vorname Nachname"` normalisiert und zusätzlich gegen den Vornamen abgeglichen.
 
 ## Next Steps
 - Address warnings about unknown technicians by updating the spreadsheet or code.
@@ -18,4 +20,4 @@
 - Neues optionales Argument `--date` erlaubt das gewünschte Datum manuell vorzugeben.
 - `gui_app.py` bietet eine einfache Oberfläche mit Datumswahl, Start/Pause/Stopp, Namensprüfung und Logfenster.
 - Überflüssige Dateien `report.csv` und `july_analysis.csv` entfernt.
-- Alle Tests (`pytest`) laufen erfolgreich: 24 passed.
+- Alle Tests (`pytest`) laufen erfolgreich: 25 passed.

--- a/tests/test_load_calls.py
+++ b/tests/test_load_calls.py
@@ -54,6 +54,31 @@ def test_load_calls_handles_header_variations(tmp_path):
     assert summary == {"Alice": {"total": 1, "new": 1, "old": 0}}
 
 
+def test_load_calls_aggregates_all_sheets(tmp_path):
+    wb = Workbook()
+    ws1 = wb.active
+    ws1.title = "Report1"
+    ws1["A2"] = dt.datetime(2025, 7, 1)
+    ws1["A5"], ws1["B5"], ws1["C5"] = "Employee ID", "Employee Name", "Open Date Time"
+    ws1["A6"], ws1["B6"], ws1["C6"] = 1, "Alice", dt.datetime(2025, 6, 30)
+
+    ws2 = wb.create_sheet("Report2")
+    ws2["A2"] = dt.datetime(2025, 7, 1)
+    ws2["A5"], ws2["B5"], ws2["C5"] = "Employee ID", "Employee Name", "Open Date Time"
+    ws2["A6"], ws2["B6"], ws2["C6"] = 2, "Bob", dt.datetime(2025, 6, 29)
+
+    path = tmp_path / "report.xlsx"
+    wb.save(path)
+
+    target_date, summary = load_calls(path)
+
+    assert target_date == dt.date(2025, 7, 1)
+    assert summary == {
+        "Alice": {"total": 1, "new": 1, "old": 0},
+        "Bob": {"total": 1, "new": 0, "old": 1},
+    }
+
+
 def test_load_calls_missing_required_columns(tmp_path):
     wb = Workbook()
     ws = wb.active

--- a/tests/test_name_aliases.py
+++ b/tests/test_name_aliases.py
@@ -19,3 +19,8 @@ def test_removes_parentheses_and_surname():
 def test_falls_back_to_norm_when_no_match():
     valid = ["Daniyal"]
     assert na.canonical_name("Unknown", valid) == "Unknown"
+
+
+def test_matches_lastname_firstname_combination():
+    valid = ["Ammar Alali"]
+    assert na.canonical_name("Alali, Ammar (KZEWSKI)", valid) == "Ammar Alali"


### PR DESCRIPTION
## Zusammenfassung
- `canonical_name` normalisiert nun Eingaben der Form "Nachname, Vorname (Team)" zu "Vorname Nachname" und versucht zusätzlich einen Abgleich nur über den Vornamen.
- Test ergänzt, der die neue Namenslogik für "Nachname, Vorname"-Eingaben absichert.
- `SESSION_SUMMARY.md` um Hinweise zur verbesserten Namensauflösung erweitert.

## Test
- `pytest -q`
- `python - <<'PY'
from pathlib import Path
from dispatch.process_reports import process_month
process_month(Path('data/Juli_25'), Path('/tmp/Liste.xlsx'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_688fd50434188330a071f438dfa8cd14