### PR TITLE
Protokolliere unbekannte Techniker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 analysis.csv
 techniker_export.csv
 data/~$Liste.xlsx
+logs/unknown_technicians.log
 
 # Bytecode
 __pycache__/

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Tuple
 import warnings
 from contextlib import closing
+from difflib import get_close_matches
 from .name_aliases import canonical_name
 
 
@@ -102,6 +103,33 @@ MONTH_MAP = {
 }
 
 
+def log_unknown_technician(
+    name: str, path: Path, valid_names: Iterable[str], unknown_log: Path | None
+) -> None:
+    """Log an unknown technician with fuzzy suggestions.
+
+    A warning is emitted und der Vorfall wird in ``unknown_log`` protokolliert.
+    ``valid_names`` dienen als Basis für mögliche Vorschläge.
+    """
+
+    valid_map = {v.lower(): v for v in valid_names}
+    matches = get_close_matches(name.lower(), list(valid_map.keys()), n=3, cutoff=0.6)
+    suggestions = ", ".join(valid_map[m] for m in matches)
+    if suggestions:
+        logger.warning(
+            "Unknown technician '%s' in %s (meintest du: %s)", name, path, suggestions
+        )
+    else:
+        logger.warning("Unknown technician '%s' in %s", name, path)
+
+    if unknown_log is not None:
+        unknown_log.parent.mkdir(parents=True, exist_ok=True)
+        with unknown_log.open("a", encoding="utf-8") as fh:
+            fh.write(
+                f"{dt.datetime.now().isoformat()}\t{path}\t{name}\t{suggestions}\n"
+            )
+
+
 def excel_to_date(value):
     """Convert an Excel serial or datetime to a :class:`datetime.date`."""
     if isinstance(value, dt.datetime):
@@ -118,7 +146,11 @@ def prev_business_day(day: dt.date) -> dt.date:
     return day
 
 
-def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt.date, Dict[str, Dict[str, int]]]:
+def load_calls(
+    path: Path,
+    valid_names: Iterable[str] | None = None,
+    unknown_log: Path | None = Path("logs/unknown_technicians.log"),
+) -> Tuple[dt.date, Dict[str, Dict[str, int]]]:
     """Load a call report and summarise per technician.
 
     Parameters
@@ -200,7 +232,7 @@ def load_calls(path: Path, valid_names: Iterable[str] | None = None) -> Tuple[dt
             raise ValueError("Header row not found in report")
 
         for name in sorted(unknown):
-            logger.warning("Unknown technician '%s' in %s", name, path)
+            log_unknown_technician(name, path, valid_names or [], unknown_log)
         return target_date, summary
 
 

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -51,12 +51,9 @@
 - Repository erneut geprüft, keine Konflikte.
 - Tests mit `pytest -q` ausgeführt: alle 24 Tests bestanden.
 - CLI mit Beispieldatei und fehlender Datei getestet, keine Ausgabedateien erstellt.
-=======
--main
 
-Kopie der Liste.xlsx nach C:\Temp
-
-Ausführung von process_month für data/Juli_25
-
-Datum, Uhrzeit, ggf. Probleme oder Warnungen
-
+## 2025-08-10
+- Unbekannte Techniker werden nun mit Vorschlägen protokolliert (`logs/unknown_technicians.log`).
+- Tests erweitert und mit `pytest -q` ausgeführt.
+- Monatsverarbeitung für `data/Juli_25` mit `data/Liste.xlsx` getestet; Logdatei erzeugt.
+- `.gitignore` um die neue Logdatei ergänzt.

--- a/tests/test_load_calls.py
+++ b/tests/test_load_calls.py
@@ -143,3 +143,24 @@ def test_load_calls_warns_once_per_unknown(tmp_path, caplog):
 
     warnings = [r.message for r in caplog.records if "Unknown technician" in r.message]
     assert warnings == [f"Unknown technician 'Bob' in {path}"]
+
+
+def test_load_calls_logs_unknown_with_suggestion(tmp_path, caplog):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Report"
+    ws["A2"] = dt.datetime(2025, 7, 1)
+    ws["A5"], ws["B5"], ws["C5"] = "Employee ID", "Employee Name", "Open Date Time"
+    ws["A6"], ws["B6"], ws["C6"] = 1, "Alicia", dt.datetime(2025, 6, 30)
+    path = tmp_path / "report.xlsx"
+    wb.save(path)
+    log_file = tmp_path / "unknown.log"
+
+    with caplog.at_level("WARNING"):
+        load_calls(path, ["Alice"], unknown_log=log_file)
+
+    warning = next(r.message for r in caplog.records if "Unknown technician" in r.message)
+    assert "Alicia" in warning and "Alice" in warning
+
+    content = log_file.read_text(encoding="utf-8").strip().split("\n")[-1]
+    assert "Alicia" in content and "Alice" in content


### PR DESCRIPTION
## Zusammenfassung
- Erweiterung der Report-Verarbeitung um `log_unknown_technician`, das unbekannte Techniker mit Namensvorschlägen ermittelt und protokolliert.
- `load_calls` akzeptiert jetzt ein optionales Logfile und nutzt das neue Hilfswerkzeug.
- `.gitignore` ignoriert die generierte Logdatei, neue Tests decken die Funktionalität ab.

## Testdurchführung
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd91799388330ac15290512367d4e