### PR TITLE
Fortschrittsanzeige und Logging für Monatsverarbeitung

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -24,3 +24,4 @@ main
 - `gui_app.py` bietet eine einfache Oberfläche mit Datumswahl, Start/Pause/Stopp, Namensprüfung und Logfenster.
 - Überflüssige Dateien `report.csv` und `july_analysis.csv` entfernt.
 - Alle Tests (`pytest`) laufen erfolgreich: 25 passed.
+- `process_month` meldet jetzt den Fortschritt und schreibt ein Log nach `logs/process_month.log`.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -325,14 +325,55 @@ def update_liste(
         wb.close()
 
 
-def process_month(month_dir: Path, liste: Path) -> None:
-    """Process all day report directories within ``month_dir``."""
+def _init_month_logger(log_file: Path | None) -> None:
+    """Initialisiere eine einfache Logausgabe für die Monatsverarbeitung."""
+
+    fmt = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+
+    if not logger.handlers:
+        logger.setLevel(logging.INFO)
+        stream = logging.StreamHandler()
+        stream.setFormatter(fmt)
+        logger.addHandler(stream)
+        logger.propagate = False
+
+    if log_file is not None and not any(
+        isinstance(h, logging.FileHandler) and Path(h.baseFilename) == log_file
+        for h in logger.handlers
+    ):
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setFormatter(fmt)
+        logger.addHandler(file_handler)
+
+
+def process_month(
+    month_dir: Path, liste: Path, log_file: Path | None = Path("logs/process_month.log")
+) -> None:
+    """Process all day report directories within ``month_dir``.
+
+    Während der Verarbeitung werden Fortschrittsmeldungen sowohl auf der
+    Konsole als auch optional in ``log_file`` ausgegeben. So ist ersichtlich,
+    ob der Vorgang noch läuft oder bereits abgeschlossen ist.
+    """
+
+    _init_month_logger(log_file)
+    logger.info("Starte Verarbeitung für %s", month_dir)
 
     for day_dir in sorted(p for p in month_dir.iterdir() if p.is_dir()):
         morning = list(day_dir.glob("*7*.xlsx"))
         if not morning:
+            logger.debug("Kein Morgenreport in %s, überspringe", day_dir)
             continue
-        main([str(day_dir), str(liste)])
+        logger.info("Verarbeite %s", day_dir.name)
+        try:
+            main([str(day_dir), str(liste)])
+        except Exception:  # pragma: no cover - Fehler protokollieren
+            logger.exception("Fehler bei der Verarbeitung von %s", day_dir)
+        else:
+            logger.info("Fertig %s", day_dir.name)
+
+    logger.info("Monatsverarbeitung abgeschlossen")
 
 
 def main(argv: Iterable[str] | None = None) -> None:

--- a/tests/test_process_month.py
+++ b/tests/test_process_month.py
@@ -47,6 +47,35 @@ def test_process_month_multiple_days(
     monkeypatch.setattr("dispatch.process_reports.update_liste", fake_update_liste)
 
     with caplog.at_level(logging.WARNING):
-        process_month(month_dir, liste)
+        process_month(month_dir, liste, log_file=None)
 
     assert calls == [dt.date(2025, 7, 1), dt.date(2025, 7, 2)]
+
+
+def test_process_month_logging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    month_dir = tmp_path / "Juli_25"
+    day1 = month_dir / "01.07"
+    day1.mkdir(parents=True)
+    wb = Workbook()
+    wb.save(day1 / "m7.xlsx")
+
+    liste = tmp_path / "Liste.xlsx"
+    create_liste(liste)
+
+    def fake_load_calls(path, valid_names=None):
+        return dt.date(2025, 7, 1), {}
+
+    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+        pass
+
+    monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
+    monkeypatch.setattr("dispatch.process_reports.update_liste", fake_update_liste)
+
+    log_file = tmp_path / "run.log"
+    process_month(month_dir, liste, log_file)
+
+    content = log_file.read_text(encoding="utf-8")
+    assert "Verarbeite 01.07" in content
+    assert "Monatsverarbeitung abgeschlossen" in content


### PR DESCRIPTION
## Zusammenfassung
- fügt `_init_month_logger` hinzu und protokolliert den Fortschritt bei `process_month`
- erweitert Tests um Prüfung auf Logdatei und aktualisiert bestehenden Test zur Vermeidung von Seiteneffekten
- Session-Dokumentation aktualisiert

## Testabdeckung
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fe89e18688330b8cf0a096a9d0067