### PR TITLE
Namenliste aus spezifischem Blatt lesen

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -25,3 +25,9 @@ main
 - Überflüssige Dateien `report.csv` und `july_analysis.csv` entfernt.
 - Alle Tests (`pytest`) laufen erfolgreich: 25 passed.
 - `process_month` meldet jetzt den Fortschritt und schreibt ein Log nach `logs/process_month.log`.
+
+## 2025-?? Update 2
+- `gather_valid_names` liest nun das Blatt "Technikernamen", berücksichtigt zusätzlich die Spalte "PUOOS" und entfernt doppelte Namen.
+- `AssignmentApp` dedupliziert die Liste bekannter Techniker beim Start.
+- Neue Option `--sheet` ermöglicht in `aggregate_warnings.py` und `assign_gui.py` die Auswahl eines anderen Tabellenblatts.
+- Test `test_gather_valid_names.py` ergänzt, alle Tests (`pytest`) laufen erfolgreich.

--- a/assign_gui.py
+++ b/assign_gui.py
@@ -37,7 +37,7 @@ class AssignmentApp(tk.Tk):
         ttk.Label(middle, text="Bekannte Techniker").pack()
         self.valid = tk.Listbox(middle)
         self.valid.pack(fill="both", expand=True)
-        for name in valid:
+        for name in sorted(set(valid)):
             self.valid.insert("end", name)
         self.valid.bind("<ButtonRelease-1>", self._on_drop)
 
@@ -125,10 +125,15 @@ def main(argv: list[str] | None = None) -> None:
         default=base_dir / "data" / "Liste.xlsx",
         help="Pfad zur Liste.xlsx",
     )
+    parser.add_argument(
+        "--sheet",
+        default="Technikernamen",
+        help="Name des Tabellenblatts mit Technikern",
+    )
     args = parser.parse_args(argv)
 
     try:
-        valid = gather_valid_names(args.liste)
+        valid = gather_valid_names(args.liste, sheet_name=args.sheet)
         unknown = aggregate_warnings(args.report_dir, valid)
     except RuntimeError as exc:  # missing dependency like openpyxl
         print(exc)

--- a/tests/test_gather_valid_names.py
+++ b/tests/test_gather_valid_names.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from dispatch.aggregate_warnings import gather_valid_names
+
+
+def test_gather_valid_names_reads_sheet_and_deduplicates(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Technikernamen"
+    ws.append(["Technikername", "PUOOS"])
+    ws.append(["Alice", "Ali"])
+    ws.append(["Bob", None])
+    ws.append(["Alice", ""])
+    wb.save(tmp_path / "Liste.xlsx")
+    wb.close()
+
+    names = gather_valid_names(tmp_path / "Liste.xlsx")
+    assert names == ["Ali", "Alice", "Bob"]


### PR DESCRIPTION
## Zusammenfassung
- Lese die Technikernamen explizit aus dem Tabellenblatt "Technikernamen" und berücksichtige zusätzlich die Spalte "PUOOS"; doppelte Einträge werden entfernt.
- GUI-Start bereinigt die Liste bekannter Techniker und die CLI erlaubt die Angabe des Tabellenblatts via `--sheet`.
- Neuer Test stellt sicher, dass Namen aus mehreren Spalten dedupliziert zurückgegeben werden.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ff1b2f1f48330aadddcb977d512d4