### PR TITLE
Technik-Blatt automatisch erkennen

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -25,3 +25,15 @@ main
 - Überflüssige Dateien `report.csv` und `july_analysis.csv` entfernt.
 - Alle Tests (`pytest`) laufen erfolgreich: 25 passed.
 - `process_month` meldet jetzt den Fortschritt und schreibt ein Log nach `logs/process_month.log`.
+
+## 2025-?? Update 2
+- `gather_valid_names` liest nun das Blatt "Technikernamen", berücksichtigt zusätzlich die Spalte "PUOOS" und entfernt doppelte Namen.
+- `AssignmentApp` dedupliziert die Liste bekannter Techniker beim Start.
+- Neue Option `--sheet` ermöglicht in `aggregate_warnings.py` und `assign_gui.py` die Auswahl eines anderen Tabellenblatts.
+- Test `test_gather_valid_names.py` ergänzt, alle Tests (`pytest`) laufen erfolgreich.
+
+## 2025-?? Update 3
+- `gather_valid_names` erkennt automatisch das Technik-Blatt und listet bei Fehlern alle verfügbaren Arbeitsblätter auf.
+- `assign_gui.py` und `aggregate_warnings.py` lassen `--sheet` optional und fangen fehlende Blätter ab.
+- `gui_app.py` zeigt bei fehlendem Tabellenblatt eine Fehlermeldung.
+- Zusätzlicher Test überprüft die automatische Blattwahl.

--- a/assign_gui.py
+++ b/assign_gui.py
@@ -37,7 +37,7 @@ class AssignmentApp(tk.Tk):
         ttk.Label(middle, text="Bekannte Techniker").pack()
         self.valid = tk.Listbox(middle)
         self.valid.pack(fill="both", expand=True)
-        for name in valid:
+        for name in sorted(set(valid)):
             self.valid.insert("end", name)
         self.valid.bind("<ButtonRelease-1>", self._on_drop)
 
@@ -125,14 +125,21 @@ def main(argv: list[str] | None = None) -> None:
         default=base_dir / "data" / "Liste.xlsx",
         help="Pfad zur Liste.xlsx",
     )
+    parser.add_argument(
+        "--sheet",
+        help="Name des Tabellenblatts mit Technikern",
+    )
     args = parser.parse_args(argv)
 
     try:
-        valid = gather_valid_names(args.liste)
+        valid = gather_valid_names(args.liste, sheet_name=args.sheet)
         unknown = aggregate_warnings(args.report_dir, valid)
     except RuntimeError as exc:  # missing dependency like openpyxl
         print(exc)
         print("Install required dependencies with: pip install openpyxl")
+        return
+    except ValueError as exc:
+        print(exc)
         return
 
     app = AssignmentApp(unknown, valid, args.liste)

--- a/dispatch/aggregate_warnings.py
+++ b/dispatch/aggregate_warnings.py
@@ -31,21 +31,52 @@ from .process_reports import load_calls, safe_load_workbook
 logger = logging.getLogger(__name__)
 
 
-def gather_valid_names(liste: Path) -> list[str]:
-    """Return a list of technician names from ``Liste.xlsx``.
+def gather_valid_names(liste: Path, sheet_name: str | None = None) -> list[str]:
+    """Return a sorted list of unique technician names from ``Liste.xlsx``.
 
-    Only the first column is inspected which is sufficient for our matching
-    needs.  Empty cells are ignored.
+    If *sheet_name* is ``None`` the first worksheet whose title contains
+    ``"technik"`` is used.  Otherwise the explicitly given worksheet is opened.
+    The columns ``Technikername`` und ``PUOOS`` werden eingelesen, leere Zellen
+    ignoriert und doppelte Einträge entfernt.  Ist kein passendes Tabellenblatt
+    vorhanden, wird eine :class:`ValueError` mit den vorhandenen Blattnamen
+    ausgelöst.
     """
 
-    names: list[str] = []
+    names: set[str] = set()
     with closing(safe_load_workbook(liste, read_only=True)) as wb:
-        ws = wb.active
-        for cell in ws.iter_rows(min_row=2, max_col=1, values_only=True):
-            value = cell[0]
-            if value:
-                names.append(str(value).strip())
-    return names
+        if sheet_name is None:
+            target = next(
+                (name for name in wb.sheetnames if "technik" in name.lower()),
+                None,
+            )
+            if target is None:
+                raise ValueError(
+                    f"Kein Tabellenblatt mit Technikern in {liste}; vorhanden: {', '.join(wb.sheetnames)}"
+                )
+            ws = wb[target]
+        else:
+            if sheet_name not in wb.sheetnames:
+                raise ValueError(
+                    f"Tabellenblatt {sheet_name!r} fehlt in {liste}; vorhanden: {', '.join(wb.sheetnames)}"
+                )
+            ws = wb[sheet_name]
+
+        header = next(ws.iter_rows(min_row=1, max_row=1, values_only=True))
+        wanted = [
+            idx
+            for idx, title in enumerate(header)
+            if str(title).strip().lower() in {"technikername", "puoos"}
+        ]
+        if not wanted:
+            wanted = list(range(len(header)))
+
+        for row in ws.iter_rows(min_row=2, values_only=True):
+            for idx in wanted:
+                if idx < len(row):
+                    value = row[idx]
+                    if value:
+                        names.add(str(value).strip())
+    return sorted(names)
 
 
 def aggregate_warnings(report_dir: Path, valid_names: list[str]) -> Counter[str]:
@@ -91,9 +122,12 @@ def main(argv: Iterable[str] | None = None) -> None:  # pragma: no cover - conve
     parser.add_argument(
         "--liste", type=Path, default=Path("Liste.xlsx"), help="Path to Liste.xlsx"
     )
+    parser.add_argument(
+        "--sheet", help="Name des Tabellenblatts mit Technikern"
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
 
-    valid = gather_valid_names(args.liste)
+    valid = gather_valid_names(args.liste, sheet_name=args.sheet)
     counter = aggregate_warnings(args.report_dir, valid)
     for name, count in counter.most_common():
         print(f"{name}: {count}")

--- a/gui_app.py
+++ b/gui_app.py
@@ -125,7 +125,11 @@ class DispatchApp(tk.Tk):
         if not day_dir.is_dir() or not liste.is_file():
             messagebox.showerror("Fehler", "Pfad prüfen")
             return
-        valid = aggregate_warnings.gather_valid_names(liste)
+        try:
+            valid = aggregate_warnings.gather_valid_names(liste)
+        except ValueError as exc:
+            messagebox.showerror("Fehler", str(exc))
+            return
         unknown = aggregate_warnings.aggregate_warnings(day_dir, valid)
         for name, count in unknown.items():
             logging.info("%s: %s", name, count)

--- a/tests/test_gather_valid_names.py
+++ b/tests/test_gather_valid_names.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from openpyxl import Workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from dispatch.aggregate_warnings import gather_valid_names
+
+
+def test_gather_valid_names_reads_sheet_and_deduplicates(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Technikernamen"
+    ws.append(["Technikername", "PUOOS"])
+    ws.append(["Alice", "Ali"])
+    ws.append(["Bob", None])
+    ws.append(["Alice", ""])
+    wb.save(tmp_path / "Liste.xlsx")
+    wb.close()
+
+    names = gather_valid_names(tmp_path / "Liste.xlsx")
+    assert names == ["Ali", "Alice", "Bob"]
+
+
+def test_gather_valid_names_autodetects_sheet(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Technikernamen + PUDO"
+    ws.append(["Technikername"])
+    ws.append(["Eva"])
+    wb.save(tmp_path / "Liste.xlsx")
+    wb.close()
+
+    assert gather_valid_names(tmp_path / "Liste.xlsx") == ["Eva"]


### PR DESCRIPTION
## Zusammenfassung
- `gather_valid_names` findet selbstständig ein Tabellenblatt mit "Technik" im Namen und nennt bei Fehlermeldungen alle verfügbaren Blätter.
- `assign_gui.py`, `aggregate_warnings.py` und `gui_app.py` machen das Argument `--sheet` optional und fangen fehlende Tabellenblätter ab.
- Ein neuer Test belegt die automatische Blattwahl.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ff1b2f1f48330aadddcb977d512d4