### PR TITLE
Konfliktmarkierungen entfernt und Tests repariert

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -28,17 +28,12 @@
 - `AssignmentApp` dedupliziert die Liste bekannter Techniker beim Start.
 - Neue Option `--sheet` ermöglicht in `aggregate_warnings.py` und `assign_gui.py` die Auswahl eines anderen Tabellenblatts.
 - Test `test_gather_valid_names.py` ergänzt, alle Tests (`pytest`) laufen erfolgreich.
- x6a1td-codex/fix-duplicate-technician-names-display
-=======
-moke7a-codex/fix-duplicate-technician-names-display
-main
 
 ## 2025-?? Update 3
 - `gather_valid_names` erkennt automatisch das Technik-Blatt und listet bei Fehlern alle verfügbaren Arbeitsblätter auf.
 - `assign_gui.py` und `aggregate_warnings.py` lassen `--sheet` optional und fangen fehlende Blätter ab.
 - `gui_app.py` zeigt bei fehlendem Tabellenblatt eine Fehlermeldung.
 - Zusätzlicher Test überprüft die automatische Blattwahl.
- x6a1td-codex/fix-duplicate-technician-names-display
 
 ## 2025-?? Update 4
 - `gather_valid_names` bevorzugt nun ausdrücklich das Blatt "Technikernamen" und greift nur bei Bedarf auf ein Blatt mit "technik" im Namen zurück.
@@ -48,7 +43,8 @@ main
 ## 2025-?? Update 5
 - `gather_valid_names` sucht jetzt gezielt nach einem Blatt mit "Technikernamen" im Titel und meldet einen Fehler, wenn keines gefunden wird; Monatsreiter werden dadurch ignoriert.
 - Zusätzliche Tests prüfen die neue Blattsuche sowie den Fehlerfall ohne Technik-Blatt.
-=======
-=======
-main
-main
+
+## 2025-?? Update 6
+- Versehentlich eingecheckte Merge-Konflikt-Markierungen entfernt.
+- `assign_gui.py` und `aggregate_warnings.py` akzeptieren weiterhin optional `--sheet`.
+- Tests aufgeräumt und erneut erfolgreich ausgeführt.

--- a/assign_gui.py
+++ b/assign_gui.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import annotations
 
 import argparse
@@ -110,7 +109,7 @@ class AssignmentApp(tk.Tk):
 def main(argv: list[str] | None = None) -> None:
     base_dir = Path(__file__).resolve().parent
     parser = argparse.ArgumentParser(
-        description="Interaktive Zuordnung unbekannter Techniker"
+        description="Interaktive Zuordnung unbekannter Techniker",
     )
     parser.add_argument(
         "report_dir",
@@ -127,13 +126,6 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument(
         "--sheet",
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
-=======
-      moke7a-codex/fix-duplicate-technician-names-display
-=======
-        default="Technikernamen"
-      main
->>>>>> main
         help="Name des Tabellenblatts mit Technikern",
     )
     args = parser.parse_args(argv)
@@ -155,3 +147,4 @@ def main(argv: list[str] | None = None) -> None:
 
 if __name__ == "__main__":  # pragma: no cover - GUI entry point
     main()
+

--- a/dispatch/aggregate_warnings.py
+++ b/dispatch/aggregate_warnings.py
@@ -31,59 +31,26 @@ from .process_reports import load_calls, safe_load_workbook
 logger = logging.getLogger(__name__)
 
 
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
 def gather_valid_names(liste: Path, sheet_name: str | None = None) -> list[str]:
-    """Lese eindeutige Techniker aus ``Liste.xlsx``.
+    """Gib eine sortierte Liste einzigartiger Techniker aus ``Liste.xlsx`` zurück.
 
-    Ohne Angabe von *sheet_name* wird nach einem Tabellenblatt gesucht, dessen
+    Ohne Angabe von *sheet_name* wird das erste Tabellenblatt gewählt, dessen
     Titel ``"Technikernamen"`` enthält. Ist kein entsprechendes Blatt
-    vorhanden, werden die vorhandenen Blattnamen gemeldet. Über ``--sheet`` kann
-    ein beliebiges Blatt explizit gewählt werden. Die Spalten ``Technikername``
-    und ``PUOOS`` werden eingelesen, leere Zellen ignoriert und doppelte
-    Einträge entfernt.
-=======
-moke7a-codex/fix-duplicate-technician-names-display
-def gather_valid_names(liste: Path, sheet_name: str | None = None) -> list[str]:
-    """Return a sorted list of unique technician names from ``Liste.xlsx``.
-
-    If *sheet_name* is ``None`` the first worksheet whose title contains
-    ``"technik"`` is used.  Otherwise the explicitly given worksheet is opened.
-    The columns ``Technikername`` und ``PUOOS`` werden eingelesen, leere Zellen
-    ignoriert und doppelte Einträge entfernt.  Ist kein passendes Tabellenblatt
     vorhanden, wird eine :class:`ValueError` mit den vorhandenen Blattnamen
-    ausgelöst.
-=======
-def gather_valid_names(liste: Path, sheet_name: str = "Technikernamen") -> list[str]:
-    """Return a sorted list of unique technician names from ``Liste.xlsx``.
-
-    The worksheet *sheet_name* is inspected and the columns ``Technikername``
-    and ``PUOOS`` are read.  Empty cells are ignored and duplicates removed.
-    If the worksheet does not exist a :class:`ValueError` is raised.
-main
->>>>>> main
+    ausgelöst. Die Spalten ``Technikername`` und ``PUOOS`` werden eingelesen,
+    leere Zellen ignoriert und doppelte Einträge entfernt.
     """
 
     names: set[str] = set()
     with closing(safe_load_workbook(liste, read_only=True)) as wb:
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
         if sheet_name is None:
             target = next(
                 (name for name in wb.sheetnames if "technikernamen" in name.lower()),
-=======
-moke7a-codex/fix-duplicate-technician-names-display
-        if sheet_name is None:
-            target = next(
-                (name for name in wb.sheetnames if "technik" in name.lower()),
->>>>>> main
                 None,
             )
             if target is None:
                 raise ValueError(
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
                     f"Kein Tabellenblatt mit 'Technikernamen' in {liste}; vorhanden: {', '.join(wb.sheetnames)}"
-=======
-                    f"Kein Tabellenblatt mit Technikern in {liste}; vorhanden: {', '.join(wb.sheetnames)}"
->>>>>> main
                 )
             ws = wb[target]
         else:
@@ -92,15 +59,6 @@ moke7a-codex/fix-duplicate-technician-names-display
                     f"Tabellenblatt {sheet_name!r} fehlt in {liste}; vorhanden: {', '.join(wb.sheetnames)}"
                 )
             ws = wb[sheet_name]
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
-=======
-=======
-        try:
-            ws = wb[sheet_name]
-        except KeyError:  # sheet missing
-            raise ValueError(f"Tabellenblatt {sheet_name!r} fehlt in {liste}")
- main
->>>>>> main
 
         header = next(ws.iter_rows(min_row=1, max_row=1, values_only=True))
         wanted = [
@@ -163,17 +121,7 @@ def main(argv: Iterable[str] | None = None) -> None:  # pragma: no cover - conve
     parser.add_argument(
         "--liste", type=Path, default=Path("Liste.xlsx"), help="Path to Liste.xlsx"
     )
-    parser.add_argument(
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
-        "--sheet", help="Name des Tabellenblatts mit Technikern"
-=======
-moke7a-codex/fix-duplicate-technician-names-display
-        "--sheet", help="Name des Tabellenblatts mit Technikern"
-=======
-        "--sheet", default="Technikernamen", help="Name des Tabellenblatts mit Technikern"
-main
->>>>>> main
-    )
+    parser.add_argument("--sheet", help="Name des Tabellenblatts mit Technikern")
     args = parser.parse_args(list(argv) if argv is not None else None)
 
     valid = gather_valid_names(args.liste, sheet_name=args.sheet)

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -57,7 +57,6 @@
 - Tests erweitert und mit `pytest -q` ausgeführt.
 - Monatsverarbeitung für `data/Juli_25` mit `data/Liste.xlsx` getestet; Logdatei erzeugt.
 - `.gitignore` um die neue Logdatei ergänzt.
-87lm7d-codex/fix-powershell-syntax-for-python-script
 ## 2025-08-10 (später, PowerShell)
 - `pytest -q` in PowerShell ausgeführt: 25 Tests bestanden, 1 übersprungen.
 - Versuch, `process_month` mit Here-Doc auszuführen, scheiterte wegen PowerShell-Syntax.
@@ -65,5 +64,8 @@
 - `process_month` lässt sich direkt mit relativen Pfaden im Repo aufrufen:
   `python -c "from pathlib import Path; from dispatch.process_reports import process_month; process_month(Path('data/Juli_25'), Path('data/Liste.xlsx'))"`
 - Keine Nutzung von `C:/Temp` notwendig; alle Pfade bleiben im Repo.
-=======
-main
+
+## 2025-08-11
+- Mergekonflikte in Quell- und Testdateien beseitigt.
+- `gather_valid_names` und GUI-Argumente bereinigt.
+- `pytest` ausgeführt: alle Tests bestanden.

--- a/tests/test_gather_valid_names.py
+++ b/tests/test_gather_valid_names.py
@@ -1,10 +1,7 @@
 import sys
 from pathlib import Path
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
 
 import pytest
-=======
->>>>>> main
 from openpyxl import Workbook
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -24,32 +21,21 @@ def test_gather_valid_names_reads_sheet_and_deduplicates(tmp_path):
 
     names = gather_valid_names(tmp_path / "Liste.xlsx")
     assert names == ["Ali", "Alice", "Bob"]
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
-=======
-moke7a-codex/fix-duplicate-technician-names-display
->>>>>> main
 
 
 def test_gather_valid_names_autodetects_sheet(tmp_path):
     wb = Workbook()
     ws = wb.active
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
     ws.title = "Technik Januar"
     ws.append(["Technikername"])
     ws.append(["Foo"])
     ws2 = wb.create_sheet("Technikernamen + PUDO")
     ws2.append(["Technikername"])
     ws2.append(["Eva"])
-=======
-    ws.title = "Technikernamen + PUDO"
-    ws.append(["Technikername"])
-    ws.append(["Eva"])
->>>>>> main
     wb.save(tmp_path / "Liste.xlsx")
     wb.close()
 
     assert gather_valid_names(tmp_path / "Liste.xlsx") == ["Eva"]
-<<<<<< x6a1td-codex/fix-duplicate-technician-names-display
 
 
 def test_gather_valid_names_raises_when_missing(tmp_path):
@@ -59,7 +45,4 @@ def test_gather_valid_names_raises_when_missing(tmp_path):
 
     with pytest.raises(ValueError):
         gather_valid_names(tmp_path / "Liste.xlsx")
-=======
-=======
-main
->>>>>> main
+


### PR DESCRIPTION
## Zusammenfassung
- Bereinigt Merge-Konflikt-Markierungen in Python-, Test- und Dokumentationsdateien
- Stellt `gather_valid_names` wieder her und lässt nur Blätter mit "Technikernamen" zu
- CLI und GUI akzeptieren weiterhin optional `--sheet`

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ffb351e6c8330bf5640d4bf716812