### PR TITLE
Filtere Nicht-Call-Aufträge

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -48,3 +48,9 @@
 - Versehentlich eingecheckte Merge-Konflikt-Markierungen entfernt.
 - `assign_gui.py` und `aggregate_warnings.py` akzeptieren weiterhin optional `--sheet`.
 - Tests aufgeräumt und erneut erfolgreich ausgeführt.
+
+## 2025-?? Update 7
+- `load_calls` berücksichtigt jetzt die Spalte "Work Order Number" und zählt nur
+  Zeilen, deren Auftragsnummer mit "17" beginnt. Stundenbuchungen und andere
+  Einträge werden ignoriert, wodurch unrealistische Tageswerte vermieden werden.
+- Neuer Test stellt sicher, dass Nicht-Call-Nummern übersprungen werden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -198,6 +198,7 @@ def load_calls(
 
             name_idx = header_map[_norm("Employee Name")]
             open_idx = header_map[_norm("Open Date Time")]
+            work_idx = header_map.get(_norm("Work Order Number"))
 
             if target_date is None:
                 target_cell = sheet.cell(row=2, column=1).value
@@ -211,6 +212,10 @@ def load_calls(
                     continue
                 if not row or row[name_idx] in (None, ""):
                     continue
+                if work_idx is not None:
+                    wo = row[work_idx]
+                    if not wo or not str(wo).startswith("17"):
+                        continue
                 tech_raw = str(row[name_idx]).strip()
                 tech = canonical_name(tech_raw, valid_names or [])
                 if valid_names and tech not in valid_names:

--- a/tests/test_load_calls.py
+++ b/tests/test_load_calls.py
@@ -164,3 +164,25 @@ def test_load_calls_logs_unknown_with_suggestion(tmp_path, caplog):
 
     content = log_file.read_text(encoding="utf-8").strip().split("\n")[-1]
     assert "Alicia" in content and "Alice" in content
+
+
+def test_load_calls_ignores_non_call_numbers(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Report"
+    ws["A2"] = dt.datetime(2025, 7, 1)
+    ws["A5"], ws["B5"], ws["C5"], ws["D5"] = (
+        "Employee ID",
+        "Employee Name",
+        "Work Order Number",
+        "Open Date Time",
+    )
+    ws["A6"], ws["B6"], ws["C6"], ws["D6"] = 1, "Alice", "17500001", dt.datetime(2025, 6, 30)
+    ws["A7"], ws["B7"], ws["C7"], ws["D7"] = 2, "Alice", "HOURS", dt.datetime(2025, 6, 30)
+    path = tmp_path / "report.xlsx"
+    wb.save(path)
+
+    target_date, summary = load_calls(path)
+
+    assert target_date == dt.date(2025, 7, 1)
+    assert summary == {"Alice": {"total": 1, "new": 1, "old": 0}}


### PR DESCRIPTION
## Zusammenfassung
- Berücksichtigt nur noch Work-Order-Nummern mit Präfix `17` beim Einlesen von Reports
- Ergänzt Test, der Nicht-Call-Einträge überspringt

## Testabdeckung
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68908e3d8e808330846cdb7054fd4b46