### PR TITLE
Monatsordner in GUI verarbeiten

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -54,3 +54,10 @@
   Zeilen, deren Auftragsnummer mit "17" beginnt. Stundenbuchungen und andere
   Einträge werden ignoriert, wodurch unrealistische Tageswerte vermieden werden.
 - Neuer Test stellt sicher, dass Nicht-Call-Nummern übersprungen werden.
+
+## 2025-?? Update 8
+- `gui_app.py` verarbeitet nun wahlweise einen einzelnen Tagesordner oder alle
+  Unterordner eines Monatsordners.
+- Damit wird ein Fehler behoben, bei dem die Verarbeitung scheiterte, wenn ein
+  Monatsordner gewählt wurde.
+- Alle Tests (`pytest`) laufen weiterhin erfolgreich.

--- a/gui_app.py
+++ b/gui_app.py
@@ -83,13 +83,22 @@ class DispatchApp(tk.Tk):
             return None
 
     def _worker_main(self, day_dir: Path, liste: Path, date: dt.date | None) -> None:
-        argv = [str(day_dir), str(liste)]
-        if date:
-            argv += ["--date", date.strftime("%d.%m.%Y")]
-        try:
-            process_reports.main(argv)
-        except Exception as exc:  # pragma: no cover - interactive
-            logging.exception("Verarbeitung fehlgeschlagen: %s", exc)
+        """Verarbeitet entweder einen Tagesordner oder alle Unterordner."""
+
+        # Ermitteln, ob direkt ein Tagesordner übergeben wurde
+        if any(day_dir.glob("*7*.xlsx")):
+            targets = [day_dir]
+        else:
+            targets = sorted(p for p in day_dir.iterdir() if p.is_dir())
+
+        for target in targets:
+            argv = [str(target), str(liste)]
+            if date and len(targets) == 1:
+                argv += ["--date", date.strftime("%d.%m.%Y")]
+            try:
+                process_reports.main(argv)
+            except Exception as exc:  # pragma: no cover - interactive
+                logging.exception("Verarbeitung fehlgeschlagen: %s", exc)
 
     def _start(self) -> None:
         if self._worker and self._worker.is_alive():


### PR DESCRIPTION
## Zusammenfassung
- GUI verarbeitet nun mehrere Tagesordner eines Monats automatisch.
- Sitzungsprotokoll aktualisiert.

## Test
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689096264ce4833097152b9986ba0e94