### PR TITLE
Korrigiere Spaltenzuordnung in update_liste

### DIFF
--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -307,7 +307,6 @@ def update_liste(
             if date_cell.value is None:
                 date_cell.value = day
             ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]
-            ws.cell(row=row, column=start_col + 7).value = day_data["total"]
             ws.cell(row=row, column=start_col + 8).value = day_data["total"]
             ws.cell(row=row, column=start_col + 9).value = day_data["old"]
             ws.cell(row=row, column=start_col + 10).value = day_data["new"]
@@ -320,7 +319,6 @@ def update_liste(
             if date_cell.value is None:
                 date_cell.value = day
             ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]
-            ws.cell(row=row, column=start_col + 7).value = day_data["total"]
             ws.cell(row=row, column=start_col + 8).value = day_data["total"]
             ws.cell(row=row, column=start_col + 9).value = day_data["old"]
             ws.cell(row=row, column=start_col + 10).value = day_data["new"]

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -69,3 +69,8 @@
 - Mergekonflikte in Quell- und Testdateien beseitigt.
 - `gather_valid_names` und GUI-Argumente bereinigt.
 - `pytest` ausgeführt: alle Tests bestanden.
+
+## 2025-08-04 (noch später)
+- Spaltenzuordnung in `update_liste` korrigiert.
+- Tests angepasst und mit `pytest -q` ausgeführt.
+- CLI mit Beispieldatei getestet und temporäre Dateien entfernt.

--- a/tests/test_update_liste.py
+++ b/tests/test_update_liste.py
@@ -25,7 +25,7 @@ def test_update_liste(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
 
-    assert ws2.cell(row=2, column=8).value == 3
+    assert ws2.cell(row=2, column=8).value is None
     assert ws2.cell(row=2, column=9).value == 3
     assert ws2.cell(row=2, column=10).value == 2
     assert ws2.cell(row=2, column=11).value == 1
@@ -61,5 +61,5 @@ def test_update_liste_multiple_runs(tmp_path: Path):
 
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
-    assert ws2.cell(row=2, column=8).value == 1
+    assert ws2.cell(row=2, column=9).value == 1
     wb2.close()


### PR DESCRIPTION
## Zusammenfassung
- Korrigiert die Zuordnung der Call-Zahlen in `update_liste`, damit Gesamt-, Alt- und Neuanrufe in die richtigen Spalten geschrieben werden.
- Passt die Tests an die neue Spaltenlogik an.
- Ergänzt das Arbeitsprotokoll um die Änderungen.

## Testen
- `pytest -q`
- `python main.py process data/Juli_25/02.07 /tmp/Liste.xlsx` (mit temporärer Datei)


------
https://chatgpt.com/codex/tasks/task_e_689096b9817c8330a793eed86b07b6d6