### PR TITLE
Berichtstag berücksichtigen und Statuslogik verfeinern

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -66,3 +66,10 @@
 - `summarize_calls.py` fasst neue und alte Calls pro Techniker zusammen.
 - `report.csv` entfernt, um überflüssige Daten zu bereinigen.
 - Neuer Test `test_summarize_calls.py`; alle Tests (`pytest`) bestehen.
+
+## 2025-?? Update 10
+- `process_calls.py` liest nun den Berichtstag aus dem Excel-Bericht,
+  berechnet den vorherigen Werktag und markiert Calls nur dann als `neu`,
+  wenn `Erstellt` genau diesem Datum entspricht.
+- Zusätzlicher Testfall prüft das Verhalten bei einem Berichtstag in der
+  Vergangenheit.

--- a/process_calls.py
+++ b/process_calls.py
@@ -5,6 +5,15 @@ from typing import Union
 import pandas as pd
 
 
+def vorheriger_werktag(referenz: dt.date) -> dt.date:
+    """Gib den letzten Werktag vor ``referenz`` zurück."""
+
+    tag = referenz - dt.timedelta(days=1)
+    while tag.weekday() >= 5:  # 5 = Samstag, 6 = Sonntag
+        tag -= dt.timedelta(days=1)
+    return tag
+
+
 def process_report(file_path: Union[str, Path], technician_name: str) -> pd.DataFrame:
     """Lese einen Excel-Bericht ein und klassifiziere Calls."""
 
@@ -12,9 +21,22 @@ def process_report(file_path: Union[str, Path], technician_name: str) -> pd.Data
     if not file_path.exists():
         raise FileNotFoundError(f"Berichtsdatei nicht gefunden: {file_path}")
 
-    # Alle Reiter laden und zu einem DataFrame kombinieren
+    # Alle Reiter laden
     all_sheets = pd.read_excel(file_path, sheet_name=None)
-    df = pd.concat(all_sheets.values(), ignore_index=True)
+
+    report_date = None
+    call_frames = []
+    for sheet in all_sheets.values():
+        if {"Techniker", "Callnr", "Erstellt"}.issubset(sheet.columns):
+            call_frames.append(sheet)
+        if report_date is None and "Berichtstag" in sheet.columns:
+            value = sheet["Berichtstag"].dropna().iloc[0]
+            report_date = pd.to_datetime(value, dayfirst=True).date()
+
+    if not call_frames:
+        raise ValueError("Keine gültigen Datenblätter gefunden")
+
+    df = pd.concat(call_frames, ignore_index=True)
 
     # Prüfen, ob alle benötigten Spalten vorhanden sind
     expected_cols = ["Techniker", "Callnr", "Erstellt"]
@@ -32,9 +54,13 @@ def process_report(file_path: Union[str, Path], technician_name: str) -> pd.Data
     # Erstellungsdatum parsen (deutsches Format Tag.Monat.Jahr)
     df["Erstellt"] = pd.to_datetime(df["Erstellt"], dayfirst=True)
 
-    # Heutiges Datum bestimmen und Status setzen
-    today = dt.datetime.now().date()
-    df["Status"] = df["Erstellt"].dt.date.apply(lambda d: "neu" if d == today else "alt")
+    # Referenzdatum bestimmen und Status setzen
+    if report_date is None:
+        report_date = dt.date.today()
+    werk_vortag = vorheriger_werktag(report_date)
+    df["Status"] = df["Erstellt"].dt.date.apply(
+        lambda d: "neu" if d == werk_vortag else "alt"
+    )
 
     return df
 

--- a/tests/test_process_calls.py
+++ b/tests/test_process_calls.py
@@ -2,12 +2,13 @@ import datetime as dt
 import pandas as pd
 import pytest
 
-from process_calls import process_report
+from process_calls import process_report, vorheriger_werktag
 
 
 def test_process_report_filters_and_classifies(tmp_path):
-    today = dt.date.today()
-    old_date = today - dt.timedelta(days=2)
+    report_date = dt.date(2024, 3, 15)
+    prev_day = vorheriger_werktag(report_date)
+    old_date = prev_day - dt.timedelta(days=2)
 
     data1 = pd.DataFrame(
         {
@@ -18,9 +19,9 @@ def test_process_report_filters_and_classifies(tmp_path):
             ],
             "Callnr": ["17500001", "18000001", "17500002"],
             "Erstellt": [
-                today.strftime("%d.%m.%Y"),
-                today.strftime("%d.%m.%Y"),
-                today.strftime("%d.%m.%Y"),
+                prev_day.strftime("%d.%m.%Y"),
+                prev_day.strftime("%d.%m.%Y"),
+                prev_day.strftime("%d.%m.%Y"),
             ],
         }
     )
@@ -30,15 +31,17 @@ def test_process_report_filters_and_classifies(tmp_path):
             "Callnr": ["17500003", "17500004"],
             "Erstellt": [
                 old_date.strftime("%d.%m.%Y"),
-                today.strftime("%d.%m.%Y"),
+                prev_day.strftime("%d.%m.%Y"),
             ],
         }
     )
+    meta = pd.DataFrame({"Berichtstag": [report_date.strftime("%d.%m.%Y")]})
 
     file_path = tmp_path / "report.xlsx"
     with pd.ExcelWriter(file_path) as writer:
         data1.to_excel(writer, index=False, sheet_name="Sheet1")
         data2.to_excel(writer, index=False, sheet_name="Sheet2")
+        meta.to_excel(writer, index=False, sheet_name="Meta")
 
     df = process_report(file_path, "Ahmad, Daniyal (Keskin)")
 
@@ -53,3 +56,31 @@ def test_process_report_filters_and_classifies(tmp_path):
 def test_process_report_missing_file():
     with pytest.raises(FileNotFoundError):
         process_report("does_not_exist.xlsx", "Ahmad, Daniyal (Keskin)")
+
+
+def test_process_report_vergangener_berichtstag(tmp_path):
+    report_date = dt.date(2024, 3, 20)
+    prev_day = vorheriger_werktag(report_date)
+
+    data = pd.DataFrame(
+        {
+            "Techniker": ["Ahmad, Daniyal (Keskin)", "Ahmad, Daniyal (Keskin)"],
+            "Callnr": ["17500005", "17500006"],
+            "Erstellt": [
+                prev_day.strftime("%d.%m.%Y"),
+                (prev_day - dt.timedelta(days=1)).strftime("%d.%m.%Y"),
+            ],
+        }
+    )
+    meta = pd.DataFrame({"Berichtstag": [report_date.strftime("%d.%m.%Y")]})
+
+    file_path = tmp_path / "report_past.xlsx"
+    with pd.ExcelWriter(file_path) as writer:
+        data.to_excel(writer, index=False, sheet_name="Daten")
+        meta.to_excel(writer, index=False, sheet_name="Meta")
+
+    df = process_report(file_path, "Ahmad, Daniyal (Keskin)")
+
+    status_map = dict(zip(df["Callnr"], df["Status"]))
+    assert status_map["17500005"] == "neu"
+    assert status_map["17500006"] == "alt"


### PR DESCRIPTION
## Zusammenfassung
- Berichtstag aus Excel-Metasheet auslesen und vorherigen Werktag bestimmen
- Status jetzt `neu`, wenn `Erstellt` dem vorherigen Werktag entspricht, sonst `alt`
- Zusätzliche Tests prüfen neue Logik inklusive vergangener Berichtstage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689282cea24c8330bba2a57ecf37c98f