### PR TITLE
Fix conflicted process_calls test

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -74,3 +74,7 @@
 - Spaltenzuordnung in `update_liste` korrigiert.
 - Tests angepasst und mit `pytest -q` ausgeführt.
 - CLI mit Beispieldatei getestet und temporäre Dateien entfernt.
+
+## 2025-08-12
+- Mergekonflikt in `tests/test_process_calls.py` aufgelöst und Parametrisierung kombiniert.
+- `pytest tests/test_process_calls.py` ausgeführt: 6 Tests bestanden.

--- a/tests/test_process_calls.py
+++ b/tests/test_process_calls.py
@@ -1,11 +1,13 @@
 import datetime as dt
+from pathlib import Path
+import sys
 import pandas as pd
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from process_calls import process_report, vorheriger_werktag
 
 
-<<<<<< codex/normalize-name-comparison-in-process_calls.py
 @pytest.mark.parametrize(
     "excel_name, query_name",
     [
@@ -16,14 +18,9 @@ from process_calls import process_report, vorheriger_werktag
     ],
 )
 def test_process_report_filters_and_classifies(tmp_path, excel_name, query_name):
-    today = dt.date.today()
-    old_date = today - dt.timedelta(days=2)
-=======
-def test_process_report_filters_and_classifies(tmp_path):
     report_date = dt.date(2024, 3, 15)
     prev_day = vorheriger_werktag(report_date)
     old_date = prev_day - dt.timedelta(days=2)
->>>>>> main
 
     data1 = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- resolve merge conflict in `test_process_calls` and parameterize name comparisons
- log test fix in `arbeitsprotokoll.md`

## Testing
- `pytest tests/test_process_calls.py`

------
https://chatgpt.com/codex/tasks/task_e_6892881a05408330a7143f326523e42a