### PR TITLE
Prüfung leerer Technik-Blätter in gather_valid_names

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -68,22 +68,16 @@
 - Neuer Test `test_summarize_calls.py`; alle Tests (`pytest`) bestehen.
 
 ## 2025-?? Update 10
-<<<<< codex/refactor-aggregate_warnings.py-for-structured-response
-- load_calls` gibt unbekannte Techniker als Liste zurück.
+- `load_calls` gibt unbekannte Techniker als Liste zurück.
 - `aggregate_warnings` wertet diese Liste direkt aus und verzichtet auf Log-Mitschnitte.
 - Tests angepasst und um eine Prüfung der Zählung unbekannter Techniker ergänzt.
 - Alle Tests (`pytest`) laufen erfolgreich: 34 passed.
-=======
-<<<<< codex/normalize-name-comparison-in-process_calls.py
-- `process_calls.py` normalisiert Techniker-Namen (Trimmen, Kleinschreibung,
-  `canonical_name` für Aliase) und filtert damit robuster.
+- `process_calls.py` normalisiert Techniker-Namen (Trimmen, Kleinschreibung, `canonical_name` für Aliase) und filtert damit robuster.
 - Testfälle berücksichtigen jetzt leichte Namensabweichungen.
 - Alle Tests (`pytest`) laufen weiterhin erfolgreich.
-=======
-- `process_calls.py` liest nun den Berichtstag aus dem Excel-Bericht,
-  berechnet den vorherigen Werktag und markiert Calls nur dann als `neu`,
-  wenn `Erstellt` genau diesem Datum entspricht.
-- Zusätzlicher Testfall prüft das Verhalten bei einem Berichtstag in der
-  Vergangenheit.
->>>>>> main
->>>>>> main
+- `process_calls.py` liest nun den Berichtstag aus dem Excel-Bericht, berechnet den vorherigen Werktag und markiert Calls nur dann als `neu`, wenn `Erstellt` genau diesem Datum entspricht.
+- Zusätzlicher Testfall prüft das Verhalten bei einem Berichtstag in der Vergangenheit.
+
+## 2025-?? Update 11
+- `gather_valid_names` gibt eine leere Liste zurück, wenn das Technikerblatt keine Zeilen enthält.
+- Neuer Test simuliert ein komplett leeres Arbeitsblatt.

--- a/dispatch/aggregate_warnings.py
+++ b/dispatch/aggregate_warnings.py
@@ -57,6 +57,8 @@ def gather_valid_names(liste: Path, sheet_name: str | None = None) -> list[str]:
                     f"Tabellenblatt {sheet_name!r} fehlt in {liste}; vorhanden: {', '.join(wb.sheetnames)}"
                 )
             ws = wb[sheet_name]
+        if ws.max_row < 1:
+            return []
 
         header = next(ws.iter_rows(min_row=1, max_row=1, values_only=True))
         wanted = [

--- a/tests/test_gather_valid_names.py
+++ b/tests/test_gather_valid_names.py
@@ -46,3 +46,19 @@ def test_gather_valid_names_raises_when_missing(tmp_path):
     with pytest.raises(ValueError):
         gather_valid_names(tmp_path / "Liste.xlsx")
 
+
+def test_gather_valid_names_handles_empty_sheet(tmp_path, monkeypatch):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Technikernamen"
+    wb.save(tmp_path / "Liste.xlsx")
+    wb.close()
+
+    from openpyxl.worksheet.worksheet import Worksheet
+    from openpyxl.worksheet._read_only import ReadOnlyWorksheet
+
+    monkeypatch.setattr(Worksheet, "max_row", property(lambda self: 0))
+    monkeypatch.setattr(ReadOnlyWorksheet, "max_row", property(lambda self: 0))
+
+    assert gather_valid_names(tmp_path / "Liste.xlsx") == []
+


### PR DESCRIPTION
## Zusammenfassung
- `gather_valid_names` liefert bei komplett leeren Technik-Blättern jetzt eine leere Liste zurück.
- Neuer Test simuliert ein leeres Blatt und prüft das Verhalten.
- Sitzungsprotokoll bereinigt und um einen Eintrag erweitert.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689289dd5ce08330be7490fd2538ecb1