### PR TITLE
Technikernamen vor Abgleich kanonisieren

### DIFF
--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -81,3 +81,9 @@
 ## 2025-?? Update 11
 - `gather_valid_names` gibt eine leere Liste zurück, wenn das Technikerblatt keine Zeilen enthält.
 - Neuer Test simuliert ein komplett leeres Arbeitsblatt.
+
+## 2025-?? Update 12
+- `process_report` bereinigt die Technikerliste nun über `canonical_name` und
+  verwendet diese kanonischen Namen zur Normalisierung.
+- Testfälle wurden erweitert, um zusätzliche Namensvarianten abzudecken.
+- Alle Tests (`pytest`) laufen weiterhin erfolgreich.

--- a/process_calls.py
+++ b/process_calls.py
@@ -50,7 +50,10 @@ def process_report(file_path: Union[str, Path], technician_name: str) -> pd.Data
     df = df[df["Callnr"].str.startswith("17")]
 
     # Namen normalisieren und auf den angegebenen Techniker filtern
-    valid_names: set[str] = set(df["Techniker"].astype(str)) | {technician_name}
+    valid_names_raw: set[str] = set(df["Techniker"].astype(str)) | {technician_name}
+    valid_names = {
+        canonical_name(name.strip(), valid_names_raw) for name in valid_names_raw
+    }
 
     def _norm(name: str) -> str:
         return canonical_name(name.strip(), valid_names).strip().lower()

--- a/tests/test_process_calls.py
+++ b/tests/test_process_calls.py
@@ -15,6 +15,7 @@ from process_calls import process_report, vorheriger_werktag
         ("Ahmad, Daniyal (Keskin)", "daniyal"),
         ("AHMAD, DANIYAL (KESKIN)", " AhMaD, Daniyal (Keskin) "),
         ("Ahmad, Daniyal (Keskin)", "Daniyal Ahmad"),
+        ("Doe, John (Team)", "john"),
     ],
 )
 def test_process_report_filters_and_classifies(tmp_path, excel_name, query_name):


### PR DESCRIPTION
## Zusammenfassung
- Verwende in `process_report` kanonische Technikerlisten für den Namensabgleich.
- Ergänze Tests um weitere Namensvariante ("Doe, John (Team)" → "john").
- Aktualisiere die Sitzungsdokumentation.

## Testen
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68928b8d61108330924bb4b425377ec2