### PR TITLE
Techniker-ID-Mapping einlesen

### DIFF
--- a/dispatch/technicians.py
+++ b/dispatch/technicians.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from openpyxl import load_workbook
+
+
+def load_id_map(liste_path: Path) -> dict[str, str]:
+    """Lese ein Mapping von Techniker-IDs zu Namen aus einer Excel-Datei.
+
+    Erwartet eine Tabelle mit den Spalten ``ID`` und ``Techniker`` im ersten
+    Arbeitsblatt. Whitespace wird entfernt und leere Zeilen werden ignoriert.
+    """
+    wb = load_workbook(liste_path, read_only=True, data_only=True)
+    ws = wb.worksheets[0]
+
+    headers = {cell.value: idx for idx, cell in enumerate(ws[1], start=1)}
+    id_col = headers.get("ID")
+    tech_col = headers.get("Techniker")
+    result: dict[str, str] = {}
+
+    if id_col is None or tech_col is None:
+        wb.close()
+        return result
+
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        id_value = row[id_col - 1]
+        tech_value = row[tech_col - 1]
+        if id_value is None or tech_value is None:
+            continue
+        key = str(id_value).strip()
+        value = str(tech_value).strip()
+        if key and value:
+            result[key] = value
+
+    wb.close()
+    return result

--- a/dispatch/tests/test_technicians.py
+++ b/dispatch/tests/test_technicians.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from openpyxl import Workbook
+
+from dispatch.technicians import load_id_map
+
+
+def test_load_id_map(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["ID", "Techniker"])
+    ws.append([" 1 ", " Alice "])
+    ws.append(["2", "Bob"])
+    ws.append([None, "Charlie"])
+    ws.append(["3", None])
+    ws.append([None, None])
+    file = tmp_path / "Liste.xlsx"
+    wb.save(file)
+    wb.close()
+
+    assert load_id_map(file) == {"1": "Alice", "2": "Bob"}

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -107,3 +107,8 @@
 ## 2025-08-06 (Batchdatei automatisiert)
 - run_all.bat auf feste Pfade ohne Abfragen umgestellt.
 - Testlauf ausgeführt; Fehler wegen fehlender Daten, aber keine Eingabeaufforderungen.
+
+## 2025-08-06 (Techniker-ID-Mapping)
+- Modul `technicians.py` mit Funktion `load_id_map` erstellt.
+- Tests hinzugefügt und mit `pytest -q` ausgeführt.
+- Keine zusätzlichen Dateien angefallen.


### PR DESCRIPTION
## Zusammenfassung
- Neues Modul `technicians.py` implementiert, das IDs und Techniker aus der ersten Excel-Tabelle liest und ein Mapping zurückgibt.
- Test `test_technicians.py` hinzugefügt, der Leerzeilen überspringt und Whitespace trimmt.
- Arbeitsprotokoll ergänzt.

## Testanweisungen
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892a97e1a64833088aa792ccc1b0f95