### PR TITLE
CLI-Unterbefehl summarize-id und Batchlauf erweitert

### DIFF
--- a/dispatch/main.py
+++ b/dispatch/main.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from . import analyze_month, process_reports
+import pandas as pd
+
+from . import analyze_month, process_reports, summarize_by_id
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -37,6 +39,14 @@ def main(argv: list[str] | None = None) -> None:
         help="Output CSV file for analysis",
     )
 
+    p_sum_id = sub.add_parser(
+        "summarize-id",
+        help="Summarize a report by technician ID",
+    )
+    p_sum_id.add_argument("excel_file", type=Path, help="Path to the Excel report")
+    p_sum_id.add_argument("liste", type=Path, help="Path to Liste.xlsx")
+    p_sum_id.add_argument("-o", "--output", type=Path, help="Output CSV file")
+
     args = parser.parse_args(argv)
 
     if args.command == "process":
@@ -48,6 +58,13 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "run-all":
         process_reports.process_month(args.month_dir, args.liste)
         analyze_month.main([str(args.month_dir), str(args.liste), "-o", str(args.output)])
+    elif args.command == "summarize-id":
+        summary = summarize_by_id.summarize_report(args.excel_file, args.liste)
+        df = pd.DataFrame(summary)
+        if args.output:
+            df.to_csv(args.output, index=False)
+        else:
+            print(df.to_string(index=False))
 
 
 if __name__ == "__main__":

--- a/logs/SESSION_SUMMARY.md
+++ b/logs/SESSION_SUMMARY.md
@@ -123,3 +123,8 @@
 - Skripte und Tests erwarten nun diese Struktur.
 - Hilfsskript `dispatch/create_day_dir.py` erstellt Tagesordner automatisch.
 - README und `run_all.bat` mit Beispielpfad aktualisiert.
+
+## 2025-08-06 Update 19
+- Unterbefehl `summarize-id` in `dispatch/main.py` hinzugefügt.
+- `run_all.bat` führt nun `summarize-id` für jeden Tagesreport aus und dokumentiert Pfade und Parameter.
+- `pytest` erfolgreich ausgeführt.

--- a/run_all.bat
+++ b/run_all.bat
@@ -1,6 +1,21 @@
 @echo off
+rem MONTH: Pfad zum Monatsordner mit Tagesreports (z. B. data\reports\2025-07)
 set "MONTH=data\reports\2025-07"
+rem LIST: Pfad zur Technikerliste
 set "LIST=Liste.xlsx"
+rem OUTPUT: Datei für die Monatsanalyse
 set "OUTPUT=report.csv"
+
+rem Monatsdaten verarbeiten und analysieren
 python -m dispatch.main run-all "%MONTH%" "%LIST%" --output "%OUTPUT%"
+
+rem Jeden Tagesreport nach Techniker-ID zusammenfassen
+for /R "%MONTH%" %%F in (*.xlsx) do (
+    for %%D in ("%%~dpF.") do (
+        rem %%~nD: Tagesordner, %%~nF: Reportname
+        python -m dispatch.main summarize-id "%%F" "%LIST%" --output "results\%%~nD_%%~nF_summary.csv"
+    )
+)
+
+rem Ausführung protokollieren
 echo %DATE% %TIME% - run_all.bat ausgeführt mit "%MONTH%" "%LIST%" "%OUTPUT%" >> "logs\arbeitsprotokoll.md"


### PR DESCRIPTION
## Zusammenfassung
- CLI um neuen Unterbefehl `summarize-id` ergänzt, der Tagesberichte nach Techniker-ID zusammenfasst.
- `run_all.bat` dokumentiert Pfadvariablen und führt `summarize-id` für jeden Tagesreport aus.
- Protokoll in `logs/SESSION_SUMMARY.md` aktualisiert.

## Tests
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892ae839d008330a501cc767aa38849