### PR TITLE
run_all filter auf 7er Reports

### DIFF
--- a/logs/SESSION_SUMMARY.md
+++ b/logs/SESSION_SUMMARY.md
@@ -128,3 +128,8 @@
 - Unterbefehl `summarize-id` in `dispatch/main.py` hinzugefügt.
 - `run_all.bat` führt nun `summarize-id` für jeden Tagesreport aus und dokumentiert Pfade und Parameter.
 - `pytest` erfolgreich ausgeführt.
+
+## 2025-08-06 Update 20
+- `run_all.bat` filtert Tagesreports nun auf Dateien mit `7` im Namen.
+- Kommentar im Skript angepasst.
+- `pytest` erfolgreich ausgeführt.

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -127,3 +127,7 @@
 - Neue Testdatei `dispatch/tests/test_summarize_by_id.py` erstellt.
 - `pytest` ausgeführt: alle 33 Tests bestanden.
 
+## 2025-08-06 (run_all-Filter)
+- `run_all.bat` durchsucht nun nur Dateien mit `7` im Namen (`*7*.xlsx`).
+- Kommentar im Skript angepasst.
+- `pytest` ausgeführt: alle Tests bestanden.

--- a/run_all.bat
+++ b/run_all.bat
@@ -9,8 +9,8 @@ set "OUTPUT=report.csv"
 rem Monatsdaten verarbeiten und analysieren
 python -m dispatch.main run-all "%MONTH%" "%LIST%" --output "%OUTPUT%"
 
-rem Jeden Tagesreport nach Techniker-ID zusammenfassen
-for /R "%MONTH%" %%F in (*.xlsx) do (
+rem Jeden Tagesreport mit "7" im Dateinamen nach Techniker-ID zusammenfassen
+for /R "%MONTH%" %%F in (*7*.xlsx) do (
     for %%D in ("%%~dpF.") do (
         rem %%~nD: Tagesordner, %%~nF: Reportname
         python -m dispatch.main summarize-id "%%F" "%LIST%" --output "results\%%~nD_%%~nF_summary.csv"


### PR DESCRIPTION
## Zusammenfassung
- Begrenze `run_all.bat` auf Dateien mit `7` im Namen.
- Kommentar im Skript überarbeitet.
- Protokolle aktualisiert.

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b4e80af4833090cbee00b7a0c647