### PR TITLE
run_all.bat protokolliert Zusammenfassungen

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -131,3 +131,8 @@
 - `run_all.bat` durchsucht nun nur Dateien mit `7` im Namen (`*7*.xlsx`).
 - Kommentar im Skript angepasst.
 - `pytest` ausgeführt: alle Tests bestanden.
+
+## 2025-08-06 (run_all-Logging)
+- `run_all.bat` legt das Verzeichnis `logs` bei Bedarf an.
+- Nach jeder `summarize-id`-Ausführung werden Report- und Ergebnisdateien protokolliert.
+- `pytest -q` ausgeführt: 33 Tests bestanden.

--- a/run_all.bat
+++ b/run_all.bat
@@ -6,6 +6,9 @@ set "LIST=Liste.xlsx"
 rem OUTPUT: Datei für die Monatsanalyse
 set "OUTPUT=report.csv"
 
+rem sicherstellen, dass das Logs-Verzeichnis existiert
+if not exist "logs" mkdir "logs"
+
 rem Monatsdaten verarbeiten und analysieren
 python -m dispatch.main run-all "%MONTH%" "%LIST%" --output "%OUTPUT%"
 
@@ -14,6 +17,7 @@ for /R "%MONTH%" %%F in (*7*.xlsx) do (
     for %%D in ("%%~dpF.") do (
         rem %%~nD: Tagesordner, %%~nF: Reportname
         python -m dispatch.main summarize-id "%%F" "%LIST%" --output "results\%%~nD_%%~nF_summary.csv"
+        echo %DATE% %TIME% - Report "%%F" -> "results\%%~nD_%%~nF_summary.csv" >> "logs\arbeitsprotokoll.md"
     )
 )
 


### PR DESCRIPTION
## Zusammenfassung
- run_all.bat legt das logs-Verzeichnis bei Bedarf an.
- Nach jedem summarize-id-Aufruf wird der Report und die Ergebnisdatei in logs/arbeitsprotokoll.md protokolliert.
- Arbeitsprotokoll entsprechend ergänzt.

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b654e27883309e17214639a53d82