### PR TITLE
README beschreibt summarize-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Automatisiert die Auswertung von täglichen Anrufberichten der Servicetechniker 
 2. Führe `run_all.bat` aus und beantworte die abgefragten Pfade.
 3. Die Ergebnisse werden in `Liste.xlsx` geschrieben und unter `logs/` protokolliert.
 
+## Auswertung nach Techniker-ID
+
+Ein einzelner Tagesbericht lässt sich mit `summarize-id` nach Techniker-IDs zusammenfassen:
+
+```bash
+python -m dispatch.main summarize-id data/report.xlsx data/Liste.xlsx --output results/2025-08-06.csv
+```
+
+Die Ausgabedatei landet im Verzeichnis `results/`.
+
 Optional kann der Tagesordner mit `python -m dispatch.create_day_dir` automatisch erstellt werden.
 
 ## Daten und Ergebnisse

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -136,3 +136,9 @@
 - `run_all.bat` legt das Verzeichnis `logs` bei Bedarf an.
 - Nach jeder `summarize-id`-Ausführung werden Report- und Ergebnisdateien protokolliert.
 - `pytest -q` ausgeführt: 33 Tests bestanden.
+
+## 2025-08-06 (README: summarize-id)
+- README um Abschnitt zur Nutzung von `python -m dispatch.main summarize-id` ergänzt.
+- Beispielaufruf mit Ausgabe nach `results/` dokumentiert.
+- `pytest -q` ausgeführt: alle Tests bestanden.
+- CLI `summarize-id` mit Beispieldatei ausgeführt und erzeugte Datei entfernt.


### PR DESCRIPTION
## Zusammenfassung
- README um Abschnitt zur Nutzung von `python -m dispatch.main summarize-id` ergänzt, inklusive Beispielausgabe nach `results/`.
- Arbeitsprotokoll mit Hinweis auf README-Erweiterung, Testlauf und CLI-Ausführung aktualisiert.

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b73259388330910517ed5badd295