### PR TITLE
PySimpleGUI auf Version 4.x fixiert und Dokumentation angepasst

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Automatisiert die Auswertung von täglichen Anrufberichten der Servicetechniker 
 ## Voraussetzungen
 
 - Python 3.11 oder neuer
-- Pakete: pandas, openpyxl, PySimpleGUI (`dispatch/requirements.txt`)
-- Installation: `pip install -r dispatch/requirements.txt`
+- Pakete: pandas, openpyxl, PySimpleGUI 4.x (`dispatch/requirements.txt`)
+- Installation: `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt`
 
 ## Kurzanleitung
 

--- a/dispatch/requirements.txt
+++ b/dispatch/requirements.txt
@@ -1,3 +1,3 @@
 openpyxl>=3.0
 pandas>=2.0
-PySimpleGUI
+PySimpleGUI~=4.60

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -167,3 +167,10 @@
 - README-Voraussetzungen um Paket und Installationshinweis ergänzt.
 - `pip install -r dispatch/requirements.txt` ausgeführt.
 - `pytest -q` ausgeführt: 34 Tests bestanden.
+
+## 2025-08-06 (PySimpleGUI 4.x Fix)
+- PySimpleGUI-Version in `dispatch/requirements.txt` auf `~=4.60` beschränkt.
+- README um Hinweis auf PySimpleGUI 4.x und Installationsbefehl mit privatem Index erweitert.
+- Hinweis zur fehlenden 5.x-Unterstützung in `run_all_gui.py` ergänzt.
+- `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt` ausgeführt: Paket 4.x nicht gefunden.
+- `pytest -q` ausgeführt: 34 Tests bestanden.

--- a/run_all_gui.py
+++ b/run_all_gui.py
@@ -6,6 +6,9 @@ Dieses Skript bietet eine GUI zur Auswahl eines Tages oder eines gesamten
 Monats und führt anschließend die bekannten Auswertungen durch. Die
 Funktionen können auch ohne GUI verwendet werden, was das Testen in
 Headless-Umgebungen erleichtert.
+
+Hinweis: Die GUI basiert auf PySimpleGUI 4.x; eine Umstellung auf 5.x wurde
+noch nicht vorgenommen.
 """
 
 from datetime import datetime


### PR DESCRIPTION
## Zusammenfassung
- PySimpleGUI in den Anforderungen auf `~=4.60` festgelegt
- README um Hinweis auf PySimpleGUI 4.x und Installationsbefehl mit privatem Index erweitert
- run_all_gui.py mit Verweis auf fehlende 5.x-Unterstützung ergänzt
- Arbeitsprotokoll mit Versionsbeschränkung und Installationsversuch aktualisiert

## Test
- `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt` *(schlug fehl: kein 4.x-Paket gefunden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893219e48c88330be3e43c11c98a116