### PR TITLE
PySimpleGUI über privaten Index beziehen

### DIFF
--- a/dispatch/requirements.txt
+++ b/dispatch/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://PySimpleGUI.net/install
+PySimpleGUI>=5,<6
 openpyxl>=3.0
 pandas>=2.0
-PySimpleGUI>=5,<6

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -181,3 +181,8 @@
 - Hinweis in `run_all_gui.py` an PySimpleGUI 5.x angepasst.
 - `pip install -r dispatch/requirements.txt` ausgeführt.
 - `pytest -q` ausgeführt: 34 Tests bestanden.
+
+## 2025-08-06 (privater PySimpleGUI-Index)
+- `dispatch/requirements.txt` mit `--extra-index-url` erweitert und `PySimpleGUI`-Zeile direkt darunter verschoben.
+- `pip install -r dispatch/requirements.txt` ausgeführt.
+- `pytest -q` ausgeführt: 34 Tests bestanden.


### PR DESCRIPTION
## Zusammenfassung
- Privaten Index für PySimpleGUI in `dispatch/requirements.txt` eingetragen und PySimpleGUI-Zeile direkt darunter platziert.
- Änderungen im Arbeitsprotokoll dokumentiert.

## Testdurchführung
- `pip install -r dispatch/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893399d3a848330a724f328b9c4de74