### PR TITLE
README: Installation über privaten PySimpleGUI-Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Automatisiert die Auswertung von täglichen Anrufberichten der Servicetechniker 
 ## Voraussetzungen
 
 - Python 3.11 oder neuer
-- Pakete: pandas, openpyxl, PySimpleGUI 5.x (`dispatch/requirements.txt`)
-- Installation: `pip install -r dispatch/requirements.txt`
+- Pakete: pandas, openpyxl, PySimpleGUI 5.x (nur über privaten Index `https://PySimpleGUI.net/install` erhältlich)
+- Installation: `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt`
 
 ## Kurzanleitung
 

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -186,3 +186,9 @@
 - `dispatch/requirements.txt` mit `--extra-index-url` erweitert und `PySimpleGUI`-Zeile direkt darunter verschoben.
 - `pip install -r dispatch/requirements.txt` ausgeführt.
 - `pytest -q` ausgeführt: 34 Tests bestanden.
+
+## 2025-08-06 (README: privater Index)
+- README-Voraussetzungen um Hinweis auf privaten PySimpleGUI-Index ergänzt.
+- Installationsbefehl auf `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt` geändert.
+- `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt` ausgeführt.
+- `pytest -q` ausgeführt: 34 Tests bestanden.


### PR DESCRIPTION
## Zusammenfassung
- README-Voraussetzungen erwähnen jetzt den privaten PySimpleGUI-Index.
- Installationsbefehl nutzt `--extra-index-url https://PySimpleGUI.net/install`.
- Arbeitsprotokoll um entsprechenden Eintrag ergänzt.

## Test
- `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933a9ec94c8330b2d2fec992e9d704