### PR TITLE
Prüfung auf PySimpleGUI-Theme hinzugefügt

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -192,3 +192,8 @@
 - Installationsbefehl auf `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt` geändert.
 - `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt` ausgeführt.
 - `pytest -q` ausgeführt: 34 Tests bestanden.
+
+## 2025-08-06 (PySimpleGUI Theme-Check)
+- In `run_all_gui.py` wird nach dem Import von PySimpleGUI geprüft, ob `sg` eine Funktion `theme` besitzt.
+- Falls nicht, wird eine verständliche Fehlermeldung mit Hinweis auf den privaten Index ausgegeben und das Programm beendet.
+- `python -m py_compile run_all_gui.py` und `pytest -q` ausgeführt: 34 Tests bestanden.

--- a/run_all_gui.py
+++ b/run_all_gui.py
@@ -13,6 +13,7 @@ Hinweis: Die GUI basiert auf PySimpleGUI 5.x.
 from datetime import datetime
 from pathlib import Path
 import subprocess
+import sys
 
 # Verzeichnisse für Logs und Ergebnisse
 LOG_DIR = Path("logs")
@@ -73,6 +74,13 @@ def process_month(month_dir: Path, liste: Path, output: Path) -> None:
 def run_gui() -> None:
     """Startet die grafische Oberfläche."""
     import PySimpleGUI as sg
+    if not hasattr(sg, "theme"):
+        print(
+            "PySimpleGUI unterstützt 'theme' nicht. "
+            "Bitte Version 5.x über den privaten Index installieren:\n"
+            "pip install --extra-index-url https://PySimpleGUI.net/install PySimpleGUI"
+        )
+        sys.exit(1)
 
     sg.theme("SystemDefault")
 


### PR DESCRIPTION
## Zusammenfassung
- Abbruch mit Hinweis auf privaten PySimpleGUI-Index, falls `sg.theme` fehlt
- Arbeitsprotokoll um neuen Eintrag zum Theme-Check erweitert

## Test
- `python -m py_compile run_all_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68933bb1cb9083309e329cc2651a2d03