### PR TITLE
summarize_by_id nutzt safe_load_workbook

### DIFF
--- a/dispatch/summarize_by_id.py
+++ b/dispatch/summarize_by_id.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from typing import List, Dict
 
 import pandas as pd
-from openpyxl import load_workbook
+
+from .process_reports import safe_load_workbook
 
 from .technicians import load_id_map
 
@@ -18,7 +19,7 @@ def summarize_report(excel_file: Path, liste_file: Path) -> List[Dict[str, objec
     id_map = load_id_map(liste_file)
     valid_ids = set(id_map)
 
-    wb = load_workbook(excel_file, read_only=True, data_only=True)
+    wb = safe_load_workbook(excel_file, read_only=True, data_only=True)
     ws = wb.worksheets[0]
     file_date_raw = ws["A2"].value
     file_date = pd.to_datetime(file_date_raw, dayfirst=True).date()

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -205,3 +205,9 @@
 2025-08-06 13:45:44 - Report "data\reports\2025-07\01\19 Uhr.xlsx" -> "results\01_19 Uhr_summary.csv"
 2025-08-06 13:45:46 - Report "data\reports\2025-07\01\7 Uhr.xlsx" -> "results\01_7 Uhr_summary.csv"
 2025-08-06 13:45:46 - run_all_gui.py ausgeführt mit "data\reports\2025-07\01" "Liste.xlsx"
+
+## 2025-08-06 (safe_load_workbook in summarize_by_id)
+- Direkten Import von `load_workbook` entfernt und `safe_load_workbook` aus `process_reports` eingebunden.
+- Aufruf in `summarize_by_id.py` angepasst.
+- `pip install -r dispatch/requirements.txt` ausgeführt.
+- `pytest -q` ausgeführt: 34 Tests bestanden.


### PR DESCRIPTION
## Zusammenfassung
- load_workbook nicht mehr direkt importiert, sondern safe_load_workbook aus process_reports eingebunden.
- Aufruf in summarize_by_id auf safe_load_workbook umgestellt.
- Arbeitsprotokoll um die Änderungen und Testläufe ergänzt.

## Tests
- `pip install -r dispatch/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893432bf50c8330b13df829e4d1c719