### PR TITLE
dispatch: Prozess vor Tageszusammenfassung ausführen

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -211,3 +211,7 @@
 - Aufruf in `summarize_by_id.py` angepasst.
 - `pip install -r dispatch/requirements.txt` ausgeführt.
 - `pytest -q` ausgeführt: 34 Tests bestanden.
+## 2025-08-06 (process vor summarize-id)
+- `summarize_day` ruft jetzt vor der Zusammenfassung `dispatch.main process` mit `day_dir` und `liste` auf.
+- Arbeitsprotokoll erweitert und Code getestet.
+- `pytest -q` ausgeführt: alle Tests bestanden.

--- a/run_all_gui.py
+++ b/run_all_gui.py
@@ -32,6 +32,18 @@ def _log(message: str) -> None:
 def summarize_day(day_dir: Path, liste: Path) -> None:
     """Fasst alle Reports eines Tages nach Techniker-ID zusammen."""
     RESULTS_DIR.mkdir(exist_ok=True)
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "dispatch.main",
+            "process",
+            str(day_dir),
+            str(liste),
+        ],
+        check=True,
+    )
+    _log(f'dispatch.main process mit "{day_dir}" "{liste}"')
     for excel in sorted(day_dir.glob("*.xlsx")):
         output = RESULTS_DIR / f"{day_dir.name}_{excel.stem}_summary.csv"
         subprocess.run(


### PR DESCRIPTION
## Zusammenfassung
- Fuehrt vor jeder Tageszusammenfassung einen Prozesslauf ueber `dispatch.main process` aus
- Dokumentiert den neuen Ablauf im Arbeitsprotokoll

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893444588b88330bd6867cd0a0eb547