### PR TITLE
Monatsblatt automatisch anlegen

### DIFF
--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -228,8 +228,10 @@ def update_liste(
     wb = safe_load_workbook(liste)
     try:
         if month_sheet not in wb.sheetnames:
-            raise KeyError(f"Worksheet {month_sheet} does not exist in {liste}")
-        ws = wb[month_sheet]
+            ws = wb.create_sheet(title=month_sheet)
+            ws.cell(row=1, column=1, value="Techniker")
+        else:
+            ws = wb[month_sheet]
 
         # Canonicalise technician names already present in the sheet
         names_in_sheet: list[str] = []
@@ -379,10 +381,13 @@ def main(argv: Iterable[str] | None = None) -> None:
     month_sheet = f"{MONTH_MAP[day.month]}_{day.strftime('%y')}"
 
     # Read existing technician names to aid fuzzy matching
-    name_wb = safe_load_workbook(args.liste, read_only=True)
+    name_wb = safe_load_workbook(args.liste)
     if month_sheet not in name_wb.sheetnames:
-        raise KeyError(f"Worksheet {month_sheet} does not exist in {args.liste}")
-    ws_names = name_wb[month_sheet]
+        ws_names = name_wb.create_sheet(title=month_sheet)
+        ws_names.cell(row=1, column=1, value="Techniker")
+        name_wb.save(args.liste)
+    else:
+        ws_names = name_wb[month_sheet]
     valid_names = [
         str(ws_names.cell(row=r, column=1).value).strip()
         for r in range(2, ws_names.max_row + 1)

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -61,3 +61,21 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     ws2 = wb2["Juli_25"]
     assert ws2.cell(row=2, column=9).value == 1
     wb2.close()
+
+
+def test_update_liste_creates_missing_sheet(tmp_path: Path):
+    file = tmp_path / "liste.xlsx"
+    wb = Workbook()
+    wb.save(file)
+
+    morning = {"Alice": {"total": 2, "new": 1, "old": 1}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    assert "Juli_25" in wb2.sheetnames
+    ws = wb2["Juli_25"]
+    assert ws.cell(row=1, column=1).value == "Techniker"
+    assert ws.cell(row=2, column=1).value == "Alice"
+    assert ws.cell(row=2, column=9).value == 2
+    wb2.close()

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -220,3 +220,8 @@
 - GUI um Eingabefeld für den Ausgabepfad ergänzt.
 - `process_month` verwendet den gewählten Pfad oder einen Standardnamen mit Monat.
 - `python -m py_compile run_all_gui.py` und `pytest -q` ausgeführt: 34 Tests bestanden.
+
+## 2025-08-06 (Monatsblatt-Prüfung)
+- `main` und `update_liste` legen fehlende Monatsblätter automatisch mit Kopfzeile an.
+- Tests für das neue Verhalten ergänzt.
+- `pytest -q` ausgeführt: 36 Tests bestanden.


### PR DESCRIPTION
## Zusammenfassung
- `main` und `update_liste` erstellen fehlende Monatsblätter mit Kopfzeile automatisch
- Tests ergänzt, die das automatische Anlegen der Blätter überprüfen
- Arbeitsprotokoll um neuen Abschnitt zur Monatsblatt-Prüfung erweitert

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893487560988330bee867d328f63d36