### PR TITLE
Fehlerbehandlung für subprocess-Aufrufe in GUI

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -225,3 +225,10 @@
 - `main` und `update_liste` legen fehlende Monatsblätter automatisch mit Kopfzeile an.
 - Tests für das neue Verhalten ergänzt.
 - `pytest -q` ausgeführt: 36 Tests bestanden.
+
+## 2025-08-06 (GUI-Fehlerbehandlung)
+- subprocess-Aufrufe in `summarize_day` und `process_month` mit `try`/`except` abgesichert.
+- Fehler werden ins Arbeitsprotokoll geschrieben und als Popup angezeigt.
+- GUI zeigt nur bei Erfolg eine Abschlussmeldung.
+- `python -m py_compile run_all_gui.py` und `pytest -q` ausgeführt: 36 Tests bestanden.
+- Keine zusätzlichen Dateien entstanden.


### PR DESCRIPTION
## Zusammenfassung
- Fehlerbehandlung in `summarize_day` und `process_month` ergänzt
- GUI zeigt Fehlermeldungen als Popup an und läuft bei Problemen weiter
- Abschlussmeldung erscheint nur bei erfolgreichem Lauf

## Test
- `python -m py_compile run_all_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689349ea9edc8330a39e5e88a84d142a