### PR TITLE
Warnung bei leerem Call-Report

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -246,3 +246,9 @@
 - `main` fragt jetzt nach Bestätigung oder Auswahl eines vorhandenen Blatts, bevor ein neues angelegt wird.
 - Tests angepasst und um Auswahl eines bestehenden Blatts ergänzt.
 - `pytest -q` ausgeführt: 38 Tests bestanden.
+
+## 2025-08-06 (Warnung bei leeren Ergebnissen)
+- `summarize_report` prüft nun, ob Filter alle Zeilen ausschließen und warnt mit Beispielen.
+- Optionaler Parameter `call_prefixes` erlaubt Anpassung der Call-Nummer-Präfixe.
+- Zusätzlicher Test für leere Ergebnisse erstellt.
+- `pytest -q` ausgeführt: 39 Tests bestanden.


### PR DESCRIPTION
## Zusammenfassung
- `summarize_report` akzeptiert nun optionale `call_prefixes` und warnt bei komplett herausgefilterten Zeilen.
- Test erweitert: prüft Warnung und leeres Ergebnis bei fehlendem passenden Call-Präfix.
- Arbeitsprotokoll aktualisiert.

## Test
- `python -m py_compile dispatch/summarize_calls.py dispatch/tests/test_summarize_calls.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689351094df08330a408e836c820ffcd