### PR TITLE
Kopfzeilenerkennung ohne Employee ID

### DIFF
--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -256,3 +256,10 @@
 - Mehrfache `Work Order Number` werden ignoriert, sodass jeder Auftrag nur einmal zählt.
 - Zwei neue Tests prüfen Filter- und Duplikaterkennung.
 - `pytest -q` ausgeführt: 41 Tests bestanden.
+
+## 2025-08-06 (Kopfzeilenerkennung)
+- `load_calls` erkennt Kopfzeilen über "Employee Name" und "Open Date Time".
+- Konstante `HEADER_MARKERS` erweitert, Berichte ohne "Employee ID" werden verarbeitet.
+- Test `test_load_calls_without_employee_id` ergänzt.
+- `pytest -q` ausgeführt: alle Tests bestanden.
+- Keine zusätzlichen Dateien entstanden.


### PR DESCRIPTION
## Summary
- `load_calls` erkennt Kopfzeilen jetzt anhand von "Employee Name" und "Open Date Time".
- neue Konstante `HEADER_MARKERS` erlaubt zusätzliche Überschriften wie "Mitarbeiter-ID".
- Testfall für Berichte ohne "Employee ID" ergänzt und fehlenden Spalten-Test angepasst.
- Arbeitsprotokoll aktualisiert.

## Testing
- `python -m py_compile dispatch/process_reports.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68935a777e8883309c51eb1d6a29d251