### PR TITLE
Berichte: mehr Blattnamen

### DIFF
--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -51,8 +51,12 @@ OPENPYXL_WARNINGS = [
 ]
 
 # Only worksheets whose title matches one of these patterns are considered
-# relevant for call extraction.
-RELEVANT_SHEET_PATTERNS = [re.compile("report", re.IGNORECASE)]
+# relevant for call extraction. Weitere im Feld verwendete Bezeichnungen wie
+# "West Central" oder "Detailed" werden nun ebenfalls berücksichtigt.
+RELEVANT_SHEET_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in ["report", "west central", "detailed"]
+]
 
 
 def safe_load_workbook(filename: Path | str, *args, **kwargs):
@@ -151,8 +155,12 @@ def load_calls(
         seen_work_orders: set[str] = set()
 
         for sheet in wb.worksheets:
-            # Skip worksheets that do not match the expected naming pattern.
-            if not any(p.search(sheet.title) for p in RELEVANT_SHEET_PATTERNS):
+            # Überspringe Arbeitsblätter, die keine der definierten
+            # Bezeichnungen enthalten. Ist die Liste leer, werden alle
+            # Blätter verarbeitet.
+            if RELEVANT_SHEET_PATTERNS and not any(
+                p.search(sheet.title) for p in RELEVANT_SHEET_PATTERNS
+            ):
                 continue
 
             header_row = None

--- a/dispatch/tests/test_load_calls.py
+++ b/dispatch/tests/test_load_calls.py
@@ -32,6 +32,28 @@ def test_load_calls_selects_correct_sheet(tmp_path):
     assert unknown == []
 
 
+def test_load_calls_handles_west_central_sheet(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "West Central"
+    ws["A2"] = dt.datetime(2025, 7, 1)
+    ws["A5"], ws["B5"], ws["C5"] = (
+        "Employee ID",
+        "Employee Name",
+        "Open Date Time",
+    )
+    ws["A6"], ws["B6"], ws["C6"] = 1, "Alice", dt.datetime(2025, 6, 30)
+
+    path = tmp_path / "report.xlsx"
+    wb.save(path)
+
+    target_date, summary, unknown = load_calls(path)
+
+    assert target_date == dt.date(2025, 7, 1)
+    assert summary == {"Alice": {"total": 1, "new": 1, "old": 0}}
+    assert unknown == []
+
+
 def test_load_calls_filters_irrelevant_sheets(tmp_path):
     wb = Workbook()
     ws1 = wb.active

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -258,3 +258,9 @@
 - `pytest -q` ausgeführt: 41 Tests bestanden.
 2025-08-06 15:28:51 - Fehler bei dispatch.main process mit "data\reports\2025-07\01" "Liste.xlsx": Command '['python', '-m', 'dispatch.main', 'process', 'data\\reports\\2025-07\\01', 'Liste.xlsx']' returned non-zero exit status 1.
 2025-08-06 17:46:23 - Fehler bei run-all mit "data\reports\2025-07" "Liste.xlsx" "C:\Users\egencer\Documents\GitHub\Dispatch\results\01_7 Uhr_summary.csv": Command '['python', '-m', 'dispatch.main', 'run-all', 'data\\reports\\2025-07', 'Liste.xlsx', '--output', 'C:\\Users\\egencer\\Documents\\GitHub\\Dispatch\\results\\01_7 Uhr_summary.csv']' returned non-zero exit status 1.
+
+## 2025-08-06 (Blattnamen)
+- `RELEVANT_SHEET_PATTERNS` um "West Central" und "Detailed" erweitert.
+- `load_calls` verarbeitet bei leerer Filterliste alle Blätter.
+- Testfall für ein Blatt "West Central" ergänzt.
+- `pytest -q` ausgeführt: 43 Tests bestanden.


### PR DESCRIPTION
## Zusammenfassung
- Blattfilter um "West Central" und "Detailed" erweitert.
- `load_calls` verarbeitet alle Blätter, wenn keine Muster definiert sind.
- Testfall für ein Blatt namens "West Central" ergänzt.

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689381c71d6c8330b0f840853416f76e