### PR TITLE
Fehlermeldung bei fehlendem Morgenreport zeigt vorhandene Dateien

### DIFF
--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -482,8 +482,11 @@ def main(argv: Iterable[str] | None = None) -> None:
         args.day_dir, args.morning_pattern
     )
     if morning is None:
+        available = sorted(p.name for p in args.day_dir.glob("*.xlsx"))
+        found = ", ".join(available) if available else "(keine)"
         raise FileNotFoundError(
-            f"Keine Excel-Dateien in {args.day_dir} gefunden"
+            f"Keine Datei nach Muster '{args.morning_pattern}' in {args.day_dir}"
+            f" gefunden. Gefundene Dateien: {found}"
         )
     if not matched:
         names = ", ".join(c.name for c in candidates)

--- a/dispatch/tests/test_main_missing_files.py
+++ b/dispatch/tests/test_main_missing_files.py
@@ -5,7 +5,7 @@ import pytest
 from openpyxl import Workbook, load_workbook
 import datetime as dt
 
-from dispatch.process_reports import main
+from dispatch.process_reports import DEFAULT_MORNING_PATTERN, main
 
 
 def create_liste(path: Path) -> None:
@@ -23,8 +23,13 @@ def test_main_no_excel_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     day_dir.mkdir(parents=True)
 
     monkeypatch.setattr(sys, "argv", ["process_reports.py", str(day_dir), str(liste)])
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError) as excinfo:
         main()
+    expected = (
+        f"Keine Datei nach Muster '{DEFAULT_MORNING_PATTERN}' in {day_dir} "
+        "gefunden. Gefundene Dateien: (keine)"
+    )
+    assert str(excinfo.value) == expected
 
 
 def test_main_missing_morning_file_uses_fallback(

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -285,3 +285,8 @@
 - Fallback nutzt erste `.xlsx`-Datei und listet vorhandene Dateien auf.
 - Tests für alternative Dateinamen und Fallback ergänzt.
 - `pytest -q` ausgeführt: 46 Tests bestanden.
+
+## 2025-08-07 (Fehlermeldung Morgenreport)
+- Fehlermeldung in `process_reports.py` nennt nun erwartetes Muster und vorhandene `.xlsx`-Dateien.
+- Test `test_main_missing_files.py` prüft die neue Meldung.
+- `pytest -q` ausgeführt: 46 Tests bestanden.


### PR DESCRIPTION
## Zusammenfassung
- Fehlermeldung nennt jetzt erwartetes Muster und aufgelistete `.xlsx`-Dateien
- Test `test_main_missing_files` prüft den genauen Wortlaut
- Arbeitsprotokoll um neuen Eintrag ergänzt

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689485ed8ea08330bc5004b08255755a