### PR TITLE
Calls je Techniker-ID erfassen

### DIFF
--- a/dispatch/summarize_by_id.py
+++ b/dispatch/summarize_by_id.py
@@ -9,7 +9,7 @@ from typing import List, Dict
 
 import pandas as pd
 
-from .process_reports import safe_load_workbook
+from .process_reports import extract_calls_by_id, safe_load_workbook
 
 from .technicians import load_id_map
 
@@ -45,6 +45,8 @@ def summarize_report(excel_file: Path, liste_file: Path) -> List[Dict[str, objec
 
     wb.close()
 
+    calls_by_id = extract_calls_by_id(excel_file, counts.keys())
+
     results: List[Dict[str, object]] = []
     for id_str, counter in counts.items():
         new = counter.get("new", 0)
@@ -56,6 +58,7 @@ def summarize_report(excel_file: Path, liste_file: Path) -> List[Dict[str, objec
                 "new": new,
                 "old": old,
                 "total": new + old,
+                "calls": calls_by_id.get(id_str, []),
             }
         )
     return results

--- a/dispatch/tests/test_main_summarize_id.py
+++ b/dispatch/tests/test_main_summarize_id.py
@@ -1,3 +1,4 @@
+import ast
 import subprocess
 from pathlib import Path
 
@@ -50,11 +51,26 @@ def test_cli_summarize_id(tmp_path: Path) -> None:
 
     df = pd.read_csv(out_csv)
     df["id"] = df["id"].astype(str)
+    df["calls"] = df["calls"].apply(ast.literal_eval)
     df = df.sort_values("id").reset_index(drop=True)
     expected = pd.DataFrame(
         [
-            {"id": "1", "name": "Alice", "new": 1, "old": 1, "total": 2},
-            {"id": "2", "name": "Bob", "new": 1, "old": 0, "total": 1},
+            {
+                "id": "1",
+                "name": "Alice",
+                "new": 1,
+                "old": 1,
+                "total": 2,
+                "calls": ["17500001", "17500002"],
+            },
+            {
+                "id": "2",
+                "name": "Bob",
+                "new": 1,
+                "old": 0,
+                "total": 1,
+                "calls": ["17500003"],
+            },
         ]
     )
     pd.testing.assert_frame_equal(df, expected)

--- a/logs/arbeitsprotokoll.md
+++ b/logs/arbeitsprotokoll.md
@@ -312,3 +312,10 @@ FileNotFoundError: Keine Excel-Dateien in C:\Users\egencer\Documents\GitHub\Disp
 2025-08-07 14:29:50 - Report "data\reports\2025-07\01\19 Uhr.xlsx" -> "results\01_19 Uhr_summary.csv"
 2025-08-07 14:29:52 - Report "data\reports\2025-07\01\7 Uhr.xlsx" -> "results\01_7 Uhr_summary.csv"
 2025-08-07 14:29:52 - run_all_gui.py ausgeführt mit "data\reports\2025-07\01" "Liste.xlsx"
+
+## 2025-08-07 (Call-Listen)
+
+- Funktion `extract_calls_by_id` in `process_reports.py` implementiert.
+- `summarize_by_id.summarize_report` ruft nun diese Funktion auf und gibt die Call-Listen zurück.
+- `run_all_gui.summarize_day` und `process_month` protokollieren die Call-Listen optional.
+- Test `test_summarize_by_id.py` um Call-Listen erweitert und neuer Test für `extract_calls_by_id` hinzugefügt.


### PR DESCRIPTION
## Zusammenfassung
- Neue Funktion `extract_calls_by_id` liest Call-Nummern pro Techniker-ID aus Reports.
- `summarize_by_id.summarize_report` liefert nun zusätzlich die zugehörigen Call-Listen zurück.
- GUI-Helfer `run_all_gui` protokolliert die Call-Listen optional je Report und Tag.
- Tests erweitern die Auswertung um Call-Listen und prüfen die Zuordnung.

## Test
- `python -m py_compile run_all_gui.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68949f438dc08330b139814fe74eea03