### PR TITLE
Ignoriere Python-Cache-Verzeichnisse und protokolliere Bereinigung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Python-Cache-Verzeichnisse
 __pycache__/
 *.pyc
 to_delete/

--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -2,3 +2,6 @@
 - Verzeichnisse logs/, results/, archive/ sowie überflüssige Daten entfernt.
 - .gitignore um ganze Verzeichnisse und Muster (*.xlsx, *.csv, *.md) erweitert.
 - Platzhalter data/reports/.gitkeep angelegt.
+- Überprüfung auf __pycache__-Ordner: keine gefunden; `git rm` meldete keine Treffer.
+- Kommentar für Python-Cache-Verzeichnisse in .gitignore ergänzt.
+- Tests mit pytest ausgeführt – 49 bestanden.


### PR DESCRIPTION
## Zusammenfassung
- Kommentar zu Python-Cache-Verzeichnissen in `.gitignore` ergänzt.
- Arbeitsprotokoll um Schritte zur Bereinigung und Testergebnisse erweitert.

## Test
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965d78da548330b2544cc4ac5bcada