### PR TITLE
Nutze pyproject und GUI-Extras

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -5,3 +5,6 @@
 - Überprüfung auf __pycache__-Ordner: keine gefunden; `git rm` meldete keine Treffer.
 - Kommentar für Python-Cache-Verzeichnisse in .gitignore ergänzt.
 - Tests mit pytest ausgeführt – 49 bestanden.
+- dispatch/requirements.txt entfernt und Abhängigkeiten in pyproject.toml im Projektwurzelverzeichnis definiert.
+- PySimpleGUI als optionale GUI-Abhängigkeit über Extras [gui] konfiguriert.
+- Tests mit pytest ausgeführt – 49 bestanden.

--- a/dispatch/requirements.txt
+++ b/dispatch/requirements.txt
@@ -1,4 +1,0 @@
---extra-index-url https://PySimpleGUI.net/install
-PySimpleGUI>=5,<6
-openpyxl>=3.0
-pandas>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dispatch"
+version = "0.1.0"
+description = "Werkzeuge für die Disposition"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "openpyxl>=3.0",
+    "pandas>=2.0",
+]
+
+[project.optional-dependencies]
+gui = ["PySimpleGUI>=5,<6"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["dispatch*"]


### PR DESCRIPTION
## Zusammenfassung
- Abhängigkeiten aus `dispatch/requirements.txt` in `pyproject.toml` verschoben.
- `PySimpleGUI` als optionales Extra `gui` definiert.

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68965ec8c53c833089a3771f60bb07e3