### PR TITLE
pyproject aktualisiert und Lizenz hinzugefügt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Team Dispatch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -19,3 +19,7 @@
 - Alle Projektdateien auf Byte Order Mark (BOM) geprüft; keine BOM gefunden.
 - arbeitsprotokoll.txt ohne BOM gespeichert.
 - Tests mit pytest ausgeführt – 49 bestanden.
+8. August 2025 (Fortsetzung 3)
+- pyproject.toml um Autorenfeld und Lizenzreferenz ergänzt.
+- MIT-Lizenzdatei LICENSE erstellt.
+- Tests mit pytest ausgeführt – fehlende Abhängigkeiten verhinderten das Laden der Module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ version = "0.1.0"
 description = "Werkzeuge für die Disposition"
 readme = "README.md"
 requires-python = ">=3.8"
+authors = [
+    {name = "Team Dispatch", email = "dispatch@example.com"},
+]
+license = {file = "LICENSE"}
 dependencies = [
     "openpyxl>=3.0",
     "pandas>=2.0",


### PR DESCRIPTION
## Zusammenfassung
- pyproject.toml um Autorenfeld und Lizenzverweis ergänzt
- MIT-Lizenzdatei im Projektwurzelverzeichnis hinzugefügt
- Arbeitsprotokoll erweitert

## Tests
- `pytest` (fehlgeschlagen: Module openpyxl und pandas fehlen)


------
https://chatgpt.com/codex/tasks/task_e_689663674c7c8330b52bff328cb148de