### PR TITLE
README um Entwicklungs- und Testhinweise ergänzt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,36 @@ Automatisiert die Auswertung von täglichen Anrufberichten der Servicetechniker 
 ## Voraussetzungen
 
 - Python 3.11 oder neuer
-- Pakete: pandas, openpyxl, PySimpleGUI 5.x (nur über privaten Index `https://PySimpleGUI.net/install` erhältlich)
-- Installation: `pip install --extra-index-url https://PySimpleGUI.net/install -r dispatch/requirements.txt`
+- Abhängigkeiten laut `pyproject.toml` oder `requirements.txt`
+- Basisinstallation: `pip install -r requirements.txt`
+- Optionale GUI: `pip install --extra-index-url https://PySimpleGUI.net/install '.[gui]'`
 
 ## Kurzanleitung
 
 1. Lege die Tagesberichte in `data/reports/<YYYY-MM>/<TT>/` ab (z. B. `data/reports/2025-07/01`) mit Dateien `*7*.xlsx` (Standard, über `--morning-pattern` konfigurierbar) und optional `*19*.xlsx`.
 2. Starte die grafische Oberfläche mit `python run_all_gui.py`.
 3. Wähle einen Tag oder den gesamten Monat aus. Die Ergebnisse werden in `Liste.xlsx` geschrieben und unter `logs/` protokolliert.
+
+## Entwicklungsumgebung
+
+- Virtuelle Umgebung: `python -m venv .venv` und Aktivierung mit `source .venv/bin/activate` (Linux/Mac) bzw. `\.venv\\Scripts\\activate` (Windows).
+- Abhängigkeiten installieren: `pip install -r requirements.txt` oder für Entwicklung `pip install -e .`.
+- Optionale GUI-Unterstützung: `pip install --extra-index-url https://PySimpleGUI.net/install '.[gui]'`.
+
+## Testausführung
+
+Die Tests laufen mit [pytest](https://pytest.org):
+
+```bash
+pytest
+```
+
+## Verzeichnisstruktur
+
+- `dispatch/` – Quellcode und Tests (`dispatch/tests/`).
+- `data/reports/` – Tagesberichte (Produktionsdaten, nicht versioniert).
+- `results/` – Ausgabedateien (nicht versioniert).
+- `logs/` – Protokolle (nicht versioniert).
 
 ## Auswertung nach Techniker-ID
 
@@ -30,4 +52,6 @@ Optional kann der Tagesordner mit `python -m dispatch.create_day_dir` automatisc
 
 - Die Ordnerstruktur `data/reports/` enthält Monatsordner (`YYYY-MM`) mit Tagesunterordnern (`TT`).
 - Während der Verarbeitung entstehen Dateien wie `analysis.csv` oder `techniker_export.csv`, die nicht versioniert werden.
+- Bei Tests kommen ausschließlich synthetische Beispieldaten zum Einsatz.
+- Produktionsdaten verbleiben lokal in `data/reports/` und werden aus Datenschutzgründen nicht versioniert.
 

--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -23,3 +23,8 @@
 - pyproject.toml um Autorenfeld und Lizenzreferenz ergänzt.
 - MIT-Lizenzdatei LICENSE erstellt.
 - Tests mit pytest ausgeführt – fehlende Abhängigkeiten verhinderten das Laden der Module.
+8. August 2025 (Fortsetzung 4)
+- README um Abschnitte zu Entwicklungsumgebung, Testausführung und Verzeichnisstruktur ergänzt.
+- Unterschied zwischen Beispiel- und Produktionsdaten dokumentiert.
+- requirements.txt erstellt und Verweis auf pyproject.toml aufgenommen.
+- Tests mit pytest ausgeführt – 49 bestanden.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.0
+openpyxl>=3.0


### PR DESCRIPTION
## Zusammenfassung
- README um Abschnitte zu Entwicklungsumgebung, Testausführung und Verzeichnisstruktur erweitert
- Unterschied zwischen Beispiel- und Produktionsdaten dokumentiert
- requirements.txt hinzugefügt und Hinweise auf pyproject.toml sowie optionale GUI-Installation ergänzt

## Test
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896645666e48330bb728c8efa636ea7