### PR TITLE
Berücksichtige Datum beim Aktualisieren der Liste

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -28,3 +28,8 @@
 - Unterschied zwischen Beispiel- und Produktionsdaten dokumentiert.
 - requirements.txt erstellt und Verweis auf pyproject.toml aufgenommen.
 - Tests mit pytest ausgeführt – 49 bestanden.
+8. August 2025 (Fortsetzung 5)
+- update_liste prüft jetzt das Datumsfeld und beschreibt Zeilen nur bei leerem oder passendem Datum.
+- Techniker werden erst nach erfolgreichem Schreiben aus der Restliste entfernt, damit Warnungen bleiben.
+- Unit-Test ergänzt, der mehrere Zeilen eines Technikers mit unterschiedlichem Datum prüft.
+- Tests mit pytest ausgeführt – 50 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -355,18 +355,24 @@ def update_liste(
         for row in range(2, ws.max_row + 1):
             name_cell = ws.cell(row=row, column=1)
             tech = str(name_cell.value).strip() if name_cell.value else None
-            if not tech or tech not in morning:
+            if not tech or tech not in morning or tech not in remaining:
                 continue
-            remaining.discard(tech)
-            day_data = morning[tech]
-            # Datum nur setzen, wenn die Zelle leer ist
+
             date_cell = ws.cell(row=row, column=start_col + 1)
+            cell_date = (
+                excel_to_date(date_cell.value) if date_cell.value is not None else None
+            )
+            if cell_date is not None and cell_date != day:
+                continue
+
+            day_data = morning[tech]
             if date_cell.value is None:
                 date_cell.value = day
             ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]
             ws.cell(row=row, column=start_col + 8).value = day_data["total"]
             ws.cell(row=row, column=start_col + 9).value = day_data["old"]
             ws.cell(row=row, column=start_col + 10).value = day_data["new"]
+            remaining.discard(tech)
 
         if remaining:
             for tech in sorted(remaining):

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from openpyxl import Workbook, load_workbook
 import pytest
 
-from dispatch.process_reports import update_liste
+from dispatch.process_reports import update_liste, excel_to_date
 
 
 def test_update_liste(tmp_path: Path):
@@ -60,6 +60,33 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
     assert ws2.cell(row=2, column=9).value == 1
+    wb2.close()
+
+
+def test_update_liste_uses_matching_date(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=2, column=1, value="Alice")
+    ws.cell(row=3, column=1, value="Alice")
+    ws.cell(row=2, column=2, value=dt.date(2025, 7, 2))
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 5, "new": 2, "old": 3}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    # Erste Zeile mit falschem Datum bleibt unverändert
+    assert excel_to_date(ws2.cell(row=2, column=2).value) == dt.date(2025, 7, 2)
+    assert ws2.cell(row=2, column=9).value is None
+    # Zweite Zeile wird für den passenden Tag beschrieben
+    assert excel_to_date(ws2.cell(row=3, column=2).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=3, column=9).value == 5
+    assert ws2.cell(row=3, column=10).value == 3
+    assert ws2.cell(row=3, column=11).value == 2
     wb2.close()
 
 


### PR DESCRIPTION
## Zusammenfassung
- Schreibe Technikerwerte in `Liste.xlsx` nur bei leerem oder passendem Datumsfeld und lasse falsche Zeilen unberührt
- Entferne Techniker erst nach erfolgreicher Aktualisierung aus der Restliste, damit Warnungen bei fehlendem Datum erhalten bleiben
- Neuer Unit-Test stellt sicher, dass bei mehrfachen Technikerzeilen nur die zum Datum passende Zeile gefüllt wird

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68966dd64d848330a8531e669d00462d