### PR TITLE
Monatsparameter für run_current_month

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Automatisiert die Auswertung von täglichen Anrufberichten der Servicetechniker 
 2. Starte die grafische Oberfläche mit `python run_all_gui.py`.
 3. Wähle einen Tag oder den gesamten Monat aus. Die Ergebnisse werden in `Liste.xlsx` geschrieben und unter `logs/` protokolliert.
 
+## Automatische Monatsverarbeitung
+
+Das Skript `run_current_month.pyw` verarbeitet den aktuellen Monat automatisch. Alternativ kann ein Monat im Format `YYYY-MM` als Parameter übergeben werden:
+
+```bash
+python run_current_month.pyw 2025-07
+```
+
+Unter Windows steht die Batch-Datei `start_dispatch.bat` zur Verfügung. Sie fragt den gewünschten Monat ab und ruft anschließend das Skript mit diesem Parameter auf.
+
 ## Entwicklungsumgebung
 
 - Virtuelle Umgebung: `python -m venv .venv` und Aktivierung mit `source .venv/bin/activate` (Linux/Mac) bzw. `\.venv\\Scripts\\activate` (Windows).

--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -37,3 +37,9 @@
 - Skript run_current_month.pyw erstellt, verarbeitet den aktuellen Monat automatisch und protokolliert das Ergebnis.
 - Batch-Datei start_dispatch.bat zum Start per Doppelklick hinzugefügt.
 - Tests mit pytest ausgeführt – 50 bestanden.
+
+8. August 2025 (Fortsetzung 7)
+- run_current_month.pyw verarbeitet optional einen übergebenen Monat und prüft das Format `YYYY-MM`.
+- start_dispatch.bat fragt den Monat ab und übergibt ihn an das Skript.
+- README um Parameterbeschreibung und Beispielaufruf ergänzt.
+- Tests mit pytest ausgeführt – 50 bestanden.

--- a/run_current_month.pyw
+++ b/run_current_month.pyw
@@ -1,5 +1,6 @@
 from datetime import date
 from pathlib import Path
+import sys
 from run_all_gui import process_month
 
 LOG_FILE = Path("arbeitsprotokoll.txt")
@@ -11,8 +12,12 @@ def log(message: str) -> None:
 
 
 def main() -> None:
-    today = date.today()
-    month_str = today.strftime("%Y-%m")
+    month_str = sys.argv[1] if len(sys.argv) > 1 else date.today().strftime("%Y-%m")
+    try:
+        date.fromisoformat(f"{month_str}-01")
+    except ValueError:
+        log(f"Ungültiges Monatsformat: {month_str}")
+        return
     month_dir = Path("data", "reports", month_str)
     liste = Path("data", "Liste.xlsx")
     output = Path("results", f"report_{month_str}.csv")

--- a/start_dispatch.bat
+++ b/start_dispatch.bat
@@ -1,2 +1,3 @@
 @echo off
-python "%~dp0run_current_month.pyw"
+set /p month=Monat (YYYY-MM) eingeben:
+python "%~dp0run_current_month.pyw" %month%


### PR DESCRIPTION
## Zusammenfassung
- run_current_month.pyw akzeptiert optionalen Monatsparameter und prüft das Format `YYYY-MM`.
- start_dispatch.bat fragt den Monat ab und übergibt ihn an das Skript.
- README erläutert die Nutzung des Parameters samt Beispiel.
- arbeitsprotokoll.txt ergänzt.

## Test
- `pytest`
- `python run_current_month.pyw 202506`

------
https://chatgpt.com/codex/tasks/task_e_68967de03f5c83309a28b533c4197ae7