### PR TITLE
Strikte Datumsprüfung in update_liste

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -38,4 +38,4 @@
 - Batch-Datei start_dispatch.bat zum Start per Doppelklick hinzugefügt.
 - Tests mit pytest ausgeführt – 50 bestanden.
 2025-08-09 - Monat 2025-08 mit Fehlern verarbeitet.
-2025-08-09 - Monat 2025-08 mit Fehlern verarbeitet.
+2025-08-09 - update_liste schreibt Werte nur bei übereinstimmendem Datum und Name; Tests angepasst; pytest 50 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -359,15 +359,10 @@ def update_liste(
                 continue
 
             date_cell = ws.cell(row=row, column=start_col + 1)
-            cell_date = (
-                excel_to_date(date_cell.value) if date_cell.value is not None else None
-            )
-            if cell_date is not None and cell_date != day:
+            if excel_to_date(date_cell.value) != day:
                 continue
 
             day_data = morning[tech]
-            if date_cell.value is None:
-                date_cell.value = day
             ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]
             ws.cell(row=row, column=start_col + 8).value = day_data["total"]
             ws.cell(row=row, column=start_col + 9).value = day_data["old"]

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -12,6 +12,7 @@ def test_update_liste(tmp_path: Path):
     ws = wb.active
     ws.title = "Juli_25"
     ws.cell(row=2, column=1, value="Alice")
+    ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
     ws.cell(row=3, column=1, value="Bob")
     file = tmp_path / "liste.xlsx"
     wb.save(file)
@@ -49,6 +50,8 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     ws = wb.active
     ws.title = "Juli_25"
     ws.cell(row=2, column=1, value="Alice")
+    ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
+    ws.cell(row=2, column=16, value=dt.date(2025, 7, 2))
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -60,6 +63,7 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
     assert ws2.cell(row=2, column=9).value == 1
+    assert ws2.cell(row=2, column=23).value == 1
     wb2.close()
 
 
@@ -70,6 +74,7 @@ def test_update_liste_uses_matching_date(tmp_path: Path):
     ws.cell(row=2, column=1, value="Alice")
     ws.cell(row=3, column=1, value="Alice")
     ws.cell(row=2, column=2, value=dt.date(2025, 7, 2))
+    ws.cell(row=3, column=2, value=dt.date(2025, 7, 1))
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 


### PR DESCRIPTION
## Zusammenfassung
- `update_liste` verarbeitet nur noch Zeilen, deren Datumszelle exakt dem Zieltag entspricht.
- Tests passen sich der neuen Logik an und füllen Datumszellen vor dem Aufruf.
- Arbeitsprotokoll ergänzt.

## Test
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b7b4c8f083309e8880138f2ef838