### PR TITLE
Berechnung der Startspalte in update_liste korrigiert

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -39,3 +39,4 @@
 - Tests mit pytest ausgeführt – 50 bestanden.
 2025-08-09 - Monat 2025-08 mit Fehlern verarbeitet.
 2025-08-09 - update_liste schreibt Werte nur bei übereinstimmendem Datum und Name; Tests angepasst; pytest 50 bestanden.
+2025-08-09 - start_col in update_liste an Wochen-/Tages-Layout angepasst; Kommentar und Test aktualisiert; pytest 50 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -15,11 +15,11 @@ corresponding month. The workbook contains weekly column blocks consisting of
     name, date, weekday, pudo, pickup time, valid, info, pre-closed,
     total calls, old calls, new calls, details, mails
 
-Blocks are repeated for each week and separated by an empty column. Each day
-occupies its own 13-column block and weeks consist of seven such blocks.
-The first block starts at column ``A``.  For a date ``d`` the week index is
-``(d.day-1)//7`` and the day index within the week is ``(d.day-1)%7``.  The
-starting column is therefore ``1 + week_index*14*7 + day_index*14``.
+Blocks sind zu Wochen gruppiert, zwischen denen eine Leer-Spalte liegt. Eine
+Woche besteht somit aus sieben 13-Spalten-Blöcken plus einer zusätzlichen
+Leer-Spalte. Für ein Datum ``d`` ergibt sich der Wochenindex ``(d.day-1)//7``
+und der Tagesindex ``(d.day-1)%7``. Die Startspalte lautet folglich
+``1 + week_index*(13*7 + 1) + day_index*13``.
 
 The script requires :mod:`openpyxl` for reading and writing Excel files.
 """
@@ -341,15 +341,14 @@ def update_liste(
 
         morning = canonicalize_summary(morning)
 
-        # Determine the start column for the given date.  ``Liste.xlsx`` stores
-        # daily values in blocks of 13 columns, separated by an empty column.
-        # Seven such blocks form a week.  The previous implementation only
-        # considered the week index which caused all days of the same week to
-        # overwrite each other.  We now also offset by the weekday inside the
-        # week so each day has its own column range.
+        # Starte Spalte gemäß dem in ``Liste.xlsx`` verwendeten Layout
+        # bestimmen. Tageswerte stehen in 13-Spalten-Blöcken, sieben Blöcke
+        # bilden eine Woche, zwischen Wochen liegt eine Leer-Spalte. Der
+        # Wochenindex und der Tagesindex innerhalb der Woche verschieben den
+        # Start entsprechend.
         week_index = (day.day - 1) // 7
         day_index = (day.day - 1) % 7
-        start_col = 1 + week_index * 14 * 7 + day_index * 14
+        start_col = 1 + week_index * (13 * 7 + 1) + day_index * 13
         remaining = set(morning)
 
         for row in range(2, ws.max_row + 1):

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -51,7 +51,7 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     ws.title = "Juli_25"
     ws.cell(row=2, column=1, value="Alice")
     ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
-    ws.cell(row=2, column=16, value=dt.date(2025, 7, 2))
+    ws.cell(row=2, column=15, value=dt.date(2025, 7, 2))
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -63,7 +63,7 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
     assert ws2.cell(row=2, column=9).value == 1
-    assert ws2.cell(row=2, column=23).value == 1
+    assert ws2.cell(row=2, column=22).value == 1
     wb2.close()
 
 


### PR DESCRIPTION
## Zusammenfassung
- Berechnung der Startspalte in `update_liste` an 13-Spalten-Blöcke mit Wochen-Trennspalte angepasst
- Testfall `test_update_liste_multiple_runs` an neue Spaltenindizes angepasst
- Arbeitsprotokoll um Eintrag zur Änderung erweitert

## Test
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b8d929d8833084044b70eaafe5a9