### PR TITLE
Popups in Tests unterdrückt

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -40,3 +40,4 @@
 2025-08-09 - Monat 2025-08 mit Fehlern verarbeitet.
 2025-08-09 - update_liste schreibt Werte nur bei übereinstimmendem Datum und Name; Tests angepasst; pytest 50 bestanden.
 2025-08-09 - start_col in update_liste an Wochen-/Tages-Layout angepasst; Kommentar und Test aktualisiert; pytest 50 bestanden.
+2025-08-09 - Popupfenster in Tests durch Monkeypatch von run_all_gui._popup_error unterdrückt; pytest 50 bestanden.

--- a/dispatch/tests/test_main_process_month_cli.py
+++ b/dispatch/tests/test_main_process_month_cli.py
@@ -34,6 +34,7 @@ def test_process_month_logs_failure(
         logs.append((msg, data))
 
     monkeypatch.setattr("run_all_gui._log", fake_log)
+    monkeypatch.setattr("run_all_gui._popup_error", lambda msg: None)
 
     def fake_process_month(m_dir, liste_path):
         raise RuntimeError("kaputt")
@@ -64,6 +65,7 @@ def test_process_month_logs_calls(
         logs.append((msg, data))
 
     monkeypatch.setattr("run_all_gui._log", fake_log)
+    monkeypatch.setattr("run_all_gui._popup_error", lambda msg: None)
 
     monkeypatch.setattr("run_all_gui.process_reports.process_month", lambda m, l: None)
     monkeypatch.setattr("run_all_gui.analyze_month.main", lambda args: None)


### PR DESCRIPTION
## Zusammenfassung
- GUI-Fehlerdialoge in `test_main_process_month_cli` per Monkeypatch deaktiviert.
- Arbeitsprotokoll um Hinweis auf deaktivierte Popups ergänzt.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897bb93981083308f9e6cc02f92b09d