### PR TITLE
excel_to_date validiert Eingaben

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -41,3 +41,4 @@
 2025-08-09 - update_liste schreibt Werte nur bei übereinstimmendem Datum und Name; Tests angepasst; pytest 50 bestanden.
 2025-08-09 - start_col in update_liste an Wochen-/Tages-Layout angepasst; Kommentar und Test aktualisiert; pytest 50 bestanden.
 2025-08-09 - Popupfenster in Tests durch Monkeypatch von run_all_gui._popup_error unterdrückt; pytest 50 bestanden.
+2025-08-09 - excel_to_date prüft nun auf leere oder ungültige Werte; optionale Nutzung von openpyxl.from_excel. Tests für fehlende und fehlerhafte Zellen ergänzt; pytest 54 bestanden.

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -110,3 +110,42 @@ def test_update_liste_creates_missing_sheet(tmp_path: Path):
     assert ws.cell(row=1, column=1).value == "Techniker"
     assert ws.max_row == 1
     wb2.close()
+
+
+def test_excel_to_date_none():
+    with pytest.raises(ValueError, match="Leere Zelle"):
+        excel_to_date(None)
+
+
+def test_excel_to_date_invalid():
+    with pytest.raises(ValueError, match="Ungültiger Datumswert"):
+        excel_to_date("abc")
+
+
+def test_update_liste_missing_date_cell(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=2, column=1, value="Alice")
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
+
+    with pytest.raises(ValueError, match="Leere Zelle"):
+        update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+
+def test_update_liste_invalid_date_cell(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=2, column=1, value="Alice")
+    ws.cell(row=2, column=2, value="abc")
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
+
+    with pytest.raises(ValueError, match="Ungültiger Datumswert"):
+        update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)


### PR DESCRIPTION
## Zusammenfassung
- Validierung in `excel_to_date`: Leere Zellen werden mit klarer Fehlermeldung abgefangen, Nicht-Zahlen führen zu ValueError. Optionaler Einsatz von `openpyxl.utils.datetime.from_excel`.
- Erweiterte Tests decken nun fehlende oder ungültige Datumszellen ab.
- Arbeitsprotokoll um die vorgenommenen Änderungen ergänzt.

## Testplan
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897bc9fe2b083309d8132fa355d4019