### PR TITLE
Techniker-Aliase und Namensnormalisierung

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -45,3 +45,4 @@
 2025-08-09 - update_liste prüft auf fehlende oder ungültige Datumswerte, überspringt solche Zeilen und protokolliert eine Warnung; Tests erweitert; pytest 54 bestanden.
 2025-08-09 - Monat 2025-07 erfolgreich verarbeitet.
 2025-08-09 - Monat 2025-07 erfolgreich verarbeitet.
+2025-08-09 - zentrale Techniker-Aliasliste und normalize_name eingeführt; Warnungen für bekannte Namen entfallen; Tests erweitert; pytest 56 bestanden.

--- a/dispatch/tests/test_load_calls.py
+++ b/dispatch/tests/test_load_calls.py
@@ -54,6 +54,28 @@ def test_load_calls_handles_west_central_sheet(tmp_path):
     assert unknown == []
 
 
+def test_load_calls_resolves_alias(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Report"
+    ws["A2"] = dt.datetime(2025, 7, 1)
+    ws["A5"], ws["B5"], ws["C5"] = (
+        "Employee ID",
+        "Employee Name",
+        "Open Date Time",
+    )
+    ws["A6"], ws["B6"], ws["C6"] = 1, "Oussama", dt.datetime(2025, 6, 30)
+
+    path = tmp_path / "report.xlsx"
+    wb.save(path)
+
+    target_date, summary, unknown = load_calls(path, ["Osama"])
+
+    assert target_date == dt.date(2025, 7, 1)
+    assert summary == {"Osama": {"total": 1, "new": 1, "old": 0}}
+    assert unknown == []
+
+
 def test_load_calls_filters_irrelevant_sheets(tmp_path):
     wb = Workbook()
     ws1 = wb.active


### PR DESCRIPTION
## Zusammenfassung
- zentrale Aliasliste und `normalize_name` für Techniker in `process_reports.py`
- Namensnormalisierung in `load_calls` und `update_liste` integriert, um Varianten wie "Oussama" zu "Osama" zusammenzuführen
- Tests für Aliasauflösung in `load_calls` und `update_liste` ergänzt

## Testdurchführung
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897c4027d108330b80f849920a8eaea