### PR TITLE
Techniker-Aliase zentralisiert

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -46,3 +46,5 @@
 2025-08-09 - Monat 2025-07 erfolgreich verarbeitet.
 2025-08-09 - Monat 2025-07 erfolgreich verarbeitet.
 2025-08-09 - zentrale Techniker-Aliasliste und normalize_name eingeführt; Warnungen für bekannte Namen entfallen; Tests erweitert; pytest 56 bestanden.
+
+2025-08-09 - normalize_name entfernt, Aliasvarianten in dispatch/name_aliases.py zentralisiert, process_reports nutzt nur canonical_name; Tests angepasst; pytest 56 bestanden.

--- a/dispatch/name_aliases.py
+++ b/dispatch/name_aliases.py
@@ -23,7 +23,8 @@ from typing import Iterable
 # Map alternate spellings or abbreviations to their canonical form.
 # Extend this mapping as needed. Keys are treated case-insensitively.
 ALIASES = {
-    # "jon doe": "John Doe",
+    "oussama": "Osama",
+    "danyal": "Daniyal",
 }
 
 # Cached lower-case mapping of aliases to canonical names.  Tests and callers

--- a/dispatch/tests/test_load_calls.py
+++ b/dispatch/tests/test_load_calls.py
@@ -6,6 +6,7 @@ import pytest
 from openpyxl import Workbook
 
 from dispatch.process_reports import load_calls, RELEVANT_SHEET_PATTERNS
+from dispatch.name_aliases import refresh_alias_map
 
 
 def test_load_calls_selects_correct_sheet(tmp_path):
@@ -55,6 +56,7 @@ def test_load_calls_handles_west_central_sheet(tmp_path):
 
 
 def test_load_calls_resolves_alias(tmp_path):
+    refresh_alias_map()
     wb = Workbook()
     ws = wb.active
     ws.title = "Report"

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -6,6 +6,7 @@ import pytest
 import logging
 
 from dispatch.process_reports import update_liste, excel_to_date
+from dispatch.name_aliases import refresh_alias_map
 
 
 def test_update_liste(tmp_path: Path):
@@ -47,6 +48,7 @@ def test_update_liste_empty_morning(tmp_path: Path):
 
 
 def test_update_liste_resolves_name_alias(tmp_path: Path, caplog):
+    refresh_alias_map()
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"


### PR DESCRIPTION
## Zusammenfassung
- Aliase wie "Oussama"→"Osama" und "Danyal"→"Daniyal" zentral in `dispatch/name_aliases.py` hinterlegt und Alias-Cache aktualisierbar gemacht.
- `process_reports` bereinigt Namen nun ausschließlich über `canonical_name` und ruft beim Import `refresh_alias_map()` auf.
- Tests für `load_calls` und `update_liste` rufen `refresh_alias_map()` und prüfen Alias-Auflösung anhand der zentralen Liste.

## Testdurchführung
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c9b5b2988330a3b711a947733047