### PR TITLE
Fehlende Techniker automatisch hinzufügen

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -51,3 +51,4 @@
 2025-08-10 - Monat 2025-08 mit Fehlern verarbeitet.
 2025-08-10 - versehentlich eingecheckte .pyc-Dateien und __pycache__-Ordner entfernt.
 2025-08-10 - update_liste setzt fehlende oder ungültige Datumszellen auf den Tageswert und verarbeitet Techniker weiter; Tests angepasst; pytest 56 bestanden.
+2025-08-10 - update_liste ergänzt fehlende Techniker durch neue Zeilen und trägt Tageswerte ein; Tests erweitert; pytest 57 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -422,7 +422,16 @@ def update_liste(
 
         if remaining:
             for tech in sorted(remaining):
-                logger.warning("Techniker %s nicht in Liste, Eintrag ignoriert.", tech)
+                canon = canonical_name(tech, names_in_sheet)
+                row = ws.max_row + 1
+                ws.cell(row=row, column=1, value=canon)
+                ws.cell(row=row, column=start_col + 1, value=day)
+                ws.cell(row=row, column=start_col + 2, value=PREV_DAY_MAP[day.weekday()])
+                day_data = morning[tech]
+                ws.cell(row=row, column=start_col + 8, value=day_data["total"])
+                ws.cell(row=row, column=start_col + 9, value=day_data["old"])
+                ws.cell(row=row, column=start_col + 10, value=day_data["new"])
+                names_in_sheet.append(canon)
 
         wb.save(liste)
     finally:

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -83,6 +83,27 @@ def test_update_liste_resolves_name_alias(tmp_path: Path, caplog):
     wb2.close()
 
 
+def test_update_liste_adds_missing_technician(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Oussama": {"total": 2, "new": 1, "old": 1}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert ws2.cell(row=2, column=1).value == "Osama"
+    assert excel_to_date(ws2.cell(row=2, column=2).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=9).value == 2
+    assert ws2.cell(row=2, column=10).value == 1
+    assert ws2.cell(row=2, column=11).value == 1
+    wb2.close()
+
+
 def test_update_liste_multiple_runs(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
@@ -146,7 +167,12 @@ def test_update_liste_creates_missing_sheet(tmp_path: Path):
     assert "Juli_25" in wb2.sheetnames
     ws = wb2["Juli_25"]
     assert ws.cell(row=1, column=1).value == "Techniker"
-    assert ws.max_row == 1
+    assert ws.max_row == 2
+    assert ws.cell(row=2, column=1).value == "Alice"
+    assert excel_to_date(ws.cell(row=2, column=2).value) == dt.date(2025, 7, 1)
+    assert ws.cell(row=2, column=9).value == 2
+    assert ws.cell(row=2, column=10).value == 1
+    assert ws.cell(row=2, column=11).value == 1
     wb2.close()
 
 


### PR DESCRIPTION
## Zusammenfassung
- Ergänzt `update_liste` um das automatische Anlegen neuer Technikerzeilen inklusive Tagesdaten.
- Erweiterte Tests stellen sicher, dass unbekannte Techniker mit kanonischem Namen eingetragen werden.
- Protokoll um Hinweis auf die neue Funktionalität ergänzt.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897cd9d2540833089a402bea4c8a227