### PR TITLE
Technikerspalte in update_liste dynamisch bestimmen

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -52,3 +52,4 @@
 2025-08-10 - versehentlich eingecheckte .pyc-Dateien und __pycache__-Ordner entfernt.
 2025-08-10 - update_liste setzt fehlende oder ungültige Datumszellen auf den Tageswert und verarbeitet Techniker weiter; Tests angepasst; pytest 56 bestanden.
 2025-08-10 - update_liste ergänzt fehlende Techniker durch neue Zeilen und trägt Tageswerte ein; Tests erweitert; pytest 57 bestanden.
+2025-08-10 - Technikerspalte dynamisch ermittelt und Startspalte relativ zu ihr berechnet; Tests angepasst, neuer Test; pytest 58 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -345,10 +345,20 @@ def update_liste(
         else:
             ws = wb[month_sheet]
 
+        # Bestimme die Spalte mit dem Header "Techniker"
+        tech_col = None
+        for col in range(1, ws.max_column + 1):
+            value = ws.cell(row=1, column=col).value
+            if isinstance(value, str) and value.strip().lower() == "techniker":
+                tech_col = col
+                break
+        if tech_col is None:
+            raise ValueError("Spalte 'Techniker' nicht gefunden")
+
         # Canonicalise technician names already present in the sheet
         names_in_sheet: list[str] = []
         for row in range(2, ws.max_row + 1):
-            cell = ws.cell(row=row, column=1)
+            cell = ws.cell(row=row, column=tech_col)
             if not cell.value:
                 continue
             canon = canonical_name(str(cell.value).strip(), names_in_sheet)
@@ -374,11 +384,11 @@ def update_liste(
         # Start entsprechend.
         week_index = (day.day - 1) // 7
         day_index = (day.day - 1) % 7
-        start_col = 1 + week_index * (13 * 7 + 1) + day_index * 13
+        start_col = tech_col + week_index * (13 * 7 + 1) + day_index * 13
         remaining = set(morning)
 
         for row in range(2, ws.max_row + 1):
-            name_cell = ws.cell(row=row, column=1)
+            name_cell = ws.cell(row=row, column=tech_col)
             tech = (
                 canonical_name(str(name_cell.value).strip(), names_in_sheet)
                 if name_cell.value
@@ -424,7 +434,7 @@ def update_liste(
             for tech in sorted(remaining):
                 canon = canonical_name(tech, names_in_sheet)
                 row = ws.max_row + 1
-                ws.cell(row=row, column=1, value=canon)
+                ws.cell(row=row, column=tech_col, value=canon)
                 ws.cell(row=row, column=start_col + 1, value=day)
                 ws.cell(row=row, column=start_col + 2, value=PREV_DAY_MAP[day.weekday()])
                 day_data = morning[tech]

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -13,6 +13,7 @@ def test_update_liste(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
     ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
     ws.cell(row=3, column=1, value="Bob")
@@ -40,6 +41,7 @@ def test_update_liste_empty_morning(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -52,6 +54,7 @@ def test_update_liste_resolves_name_alias(tmp_path: Path, caplog):
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Osama")
     ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
     file = tmp_path / "liste.xlsx"
@@ -87,6 +90,7 @@ def test_update_liste_adds_missing_technician(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -104,10 +108,32 @@ def test_update_liste_adds_missing_technician(tmp_path: Path):
     wb2.close()
 
 
+def test_update_liste_uses_technician_header_column(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=3, value="Techniker")
+    ws.cell(row=2, column=3, value="Alice")
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert ws2.cell(row=2, column=3).value == "Alice"
+    assert excel_to_date(ws2.cell(row=2, column=4).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=11).value == 1
+    wb2.close()
+
+
 def test_update_liste_multiple_runs(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
     ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
     ws.cell(row=2, column=15, value=dt.date(2025, 7, 2))
@@ -130,6 +156,7 @@ def test_update_liste_uses_matching_date(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
     ws.cell(row=3, column=1, value="Alice")
     ws.cell(row=2, column=2, value=dt.date(2025, 7, 2))
@@ -191,6 +218,7 @@ def test_update_liste_fills_invalid_date_cell(tmp_path: Path, caplog, date_value
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
     if date_value is not None:
         ws.cell(row=2, column=2, value=date_value)


### PR DESCRIPTION
## Zusammenfassung
- `update_liste` ermittelt die Spalte "Techniker" zur Laufzeit und nutzt den Index für Namens- und Datumszellen.
- Startspalte für Tagesblöcke wird relativ zur gefundenen Technikerspalte berechnet.
- Tests angepasst und neuer Test zur freien Platzierung der Überschrift hinzugefügt.
- Arbeitsprotokoll um aktuellen Eintrag erweitert.

## Testdurchführung
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ceae7820833091f8dfe3c0b9ca31