### PR TITLE
Techniker trotz falschem Datum weiterverarbeiten

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -52,3 +52,4 @@
 2025-08-10 - versehentlich eingecheckte .pyc-Dateien und __pycache__-Ordner entfernt.
 2025-08-10 - update_liste setzt fehlende oder ungültige Datumszellen auf den Tageswert und verarbeitet Techniker weiter; Tests angepasst; pytest 56 bestanden.
 2025-08-10 - update_liste ergänzt fehlende Techniker durch neue Zeilen und trägt Tageswerte ein; Tests erweitert; pytest 57 bestanden.
+2025-08-10 - update_liste überschreibt abweichende Datumsangaben mit Tageswert und verarbeitet Techniker weiter; Tests angepasst; pytest 57 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -411,7 +411,14 @@ def update_liste(
                     date_cell.value = day
                     cell_date = day
             if cell_date != day:
-                continue
+                logger.warning(
+                    "Abweichende Datumsangabe in Zeile %s für Techniker %s: %r, setze Datum auf %s.",
+                    row,
+                    tech,
+                    date_cell.value,
+                    day,
+                )
+                date_cell.value = day
 
             day_data = morning[tech]
             ws.cell(row=row, column=start_col + 2).value = PREV_DAY_MAP[day.weekday()]

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -143,14 +143,14 @@ def test_update_liste_uses_matching_date(tmp_path: Path):
 
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
-    # Erste Zeile mit falschem Datum bleibt unverändert
-    assert excel_to_date(ws2.cell(row=2, column=2).value) == dt.date(2025, 7, 2)
-    assert ws2.cell(row=2, column=9).value is None
-    # Zweite Zeile wird für den passenden Tag beschrieben
+    # Erste Zeile mit abweichendem Datum wird überschrieben und beschrieben
+    assert excel_to_date(ws2.cell(row=2, column=2).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=9).value == 5
+    assert ws2.cell(row=2, column=10).value == 3
+    assert ws2.cell(row=2, column=11).value == 2
+    # Zweite Zeile bleibt unberührt
     assert excel_to_date(ws2.cell(row=3, column=2).value) == dt.date(2025, 7, 1)
-    assert ws2.cell(row=3, column=9).value == 5
-    assert ws2.cell(row=3, column=10).value == 3
-    assert ws2.cell(row=3, column=11).value == 2
+    assert ws2.cell(row=3, column=9).value is None
     wb2.close()
 
 


### PR DESCRIPTION
## Zusammenfassung
- Bei abweichendem Datum in `update_liste` wird eine Warnung ausgegeben und die Zelle auf den Tageswert gesetzt.
- Test `test_update_liste_uses_matching_date` an das neue Verhalten angepasst.
- Arbeitsprotokoll um den Änderungseintrag ergänzt.

## Test
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d09406788330b629b4a6760b2ecc