### PR TITLE
update_liste verarbeitet verbleibende Techniker mit ws.append

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -52,7 +52,6 @@
 2025-08-10 - versehentlich eingecheckte .pyc-Dateien und __pycache__-Ordner entfernt.
 2025-08-10 - update_liste setzt fehlende oder ungültige Datumszellen auf den Tageswert und verarbeitet Techniker weiter; Tests angepasst; pytest 56 bestanden.
 2025-08-10 - update_liste ergänzt fehlende Techniker durch neue Zeilen und trägt Tageswerte ein; Tests erweitert; pytest 57 bestanden.
- codex/update-date-handling-in-update_liste
 2025-08-10 - update_liste überschreibt abweichende Datumsangaben mit Tageswert und verarbeitet Techniker weiter; Tests angepasst; pytest 57 bestanden.
 2025-08-10 - Technikerspalte dynamisch ermittelt und Startspalte relativ zu ihr berechnet; Tests angepasst, neuer Test; pytest 58 bestanden.
-main
+2025-08-10 - update_liste fügt verbleibende Techniker per ws.append als neue Zeilen hinzu und normalisiert Namen via canonical_name; pytest 58 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -437,18 +437,18 @@ def update_liste(
             ws.cell(row=row, column=start_col + 10).value = day_data["new"]
             remaining.discard(tech)
 
-        if remaining:
-            for tech in sorted(remaining):
-                canon = canonical_name(tech, names_in_sheet)
-                row = ws.max_row + 1
-                ws.cell(row=row, column=tech_col, value=canon)
-                ws.cell(row=row, column=start_col + 1, value=day)
-                ws.cell(row=row, column=start_col + 2, value=PREV_DAY_MAP[day.weekday()])
-                day_data = morning[tech]
-                ws.cell(row=row, column=start_col + 8, value=day_data["total"])
-                ws.cell(row=row, column=start_col + 9, value=day_data["old"])
-                ws.cell(row=row, column=start_col + 10, value=day_data["new"])
-                names_in_sheet.append(canon)
+        for tech in sorted(remaining):
+            canon = canonical_name(tech, names_in_sheet)
+            day_data = morning[tech]
+            row_values = [None] * (start_col + 10)
+            row_values[tech_col - 1] = canon
+            row_values[start_col] = day
+            row_values[start_col + 1] = PREV_DAY_MAP[day.weekday()]
+            row_values[start_col + 7] = day_data["total"]
+            row_values[start_col + 8] = day_data["old"]
+            row_values[start_col + 9] = day_data["new"]
+            ws.append(row_values)
+            names_in_sheet.append(canon)
 
         wb.save(liste)
     finally:


### PR DESCRIPTION
## Zusammenfassung
- Verbleibende Techniker werden nach dem Zeilendurchlauf iteriert und mit `ws.append` als neue Zeilen eingefügt.
- Namen werden per `canonical_name` normalisiert und Tageswerte gesetzt.
- Arbeitsprotokoll um die Änderung ergänzt.

## Tests
- `pytest` – 58 bestanden.

------
https://chatgpt.com/codex/tasks/task_e_6897d264f2e8833096f391da8c088271