### PR TITLE
Startspalte an Technikerspalte ausrichten

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -55,3 +55,4 @@
 2025-08-10 - update_liste überschreibt abweichende Datumsangaben mit Tageswert und verarbeitet Techniker weiter; Tests angepasst; pytest 57 bestanden.
 2025-08-10 - Technikerspalte dynamisch ermittelt und Startspalte relativ zu ihr berechnet; Tests angepasst, neuer Test; pytest 58 bestanden.
 2025-08-10 - update_liste fügt verbleibende Techniker per ws.append als neue Zeilen hinzu und normalisiert Namen via canonical_name; pytest 58 bestanden.
+2025-08-10 - Startspalte richtet sich jetzt an Technikerspalte + 1 aus; Tests angepasst; pytest 58 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -377,14 +377,14 @@ def update_liste(
 
         morning = canonicalize_summary(morning)
 
-        # Starte Spalte gemäß dem in ``Liste.xlsx`` verwendeten Layout
-        # bestimmen. Tageswerte stehen in 13-Spalten-Blöcken, sieben Blöcke
-        # bilden eine Woche, zwischen Wochen liegt eine Leer-Spalte. Der
-        # Wochenindex und der Tagesindex innerhalb der Woche verschieben den
+        # Startspalte relativ zur Technikerspalte gemäß dem in ``Liste.xlsx``
+        # verwendeten Layout bestimmen. Tageswerte stehen in 13-Spalten-Blöcken,
+        # sieben Blöcke bilden eine Woche, zwischen Wochen liegt eine Leer-Spalte.
+        # Der Wochenindex und der Tagesindex innerhalb der Woche verschieben den
         # Start entsprechend.
         week_index = (day.day - 1) // 7
         day_index = (day.day - 1) % 7
-        start_col = tech_col + week_index * (13 * 7 + 1) + day_index * 13
+        start_col = tech_col + 1 + week_index * (13 * 7 + 1) + day_index * 13
         remaining = set(morning)
 
         for row in range(2, ws.max_row + 1):

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -15,7 +15,7 @@ def test_update_liste(tmp_path: Path):
     ws.title = "Juli_25"
     ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
-    ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
+    ws.cell(row=2, column=3, value=dt.date(2025, 7, 1))
     ws.cell(row=3, column=1, value="Bob")
     file = tmp_path / "liste.xlsx"
     wb.save(file)
@@ -27,14 +27,14 @@ def test_update_liste(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
 
-    assert ws2.cell(row=2, column=8).value is None
-    assert ws2.cell(row=2, column=9).value == 3
-    assert ws2.cell(row=2, column=10).value == 2
-    assert ws2.cell(row=2, column=11).value == 1
-    assert ws2.cell(row=3, column=8).value is None
+    assert ws2.cell(row=2, column=9).value is None
+    assert ws2.cell(row=2, column=10).value == 3
+    assert ws2.cell(row=2, column=11).value == 2
+    assert ws2.cell(row=2, column=12).value == 1
     assert ws2.cell(row=3, column=9).value is None
     assert ws2.cell(row=3, column=10).value is None
     assert ws2.cell(row=3, column=11).value is None
+    assert ws2.cell(row=3, column=12).value is None
 
 
 def test_update_liste_empty_morning(tmp_path: Path):
@@ -56,7 +56,7 @@ def test_update_liste_resolves_name_alias(tmp_path: Path, caplog):
     ws.title = "Juli_25"
     ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Osama")
-    ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
+    ws.cell(row=2, column=3, value=dt.date(2025, 7, 1))
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -80,9 +80,9 @@ def test_update_liste_resolves_name_alias(tmp_path: Path, caplog):
 
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
-    assert ws2.cell(row=2, column=9).value == 2
-    assert ws2.cell(row=2, column=10).value == 1
+    assert ws2.cell(row=2, column=10).value == 2
     assert ws2.cell(row=2, column=11).value == 1
+    assert ws2.cell(row=2, column=12).value == 1
     wb2.close()
 
 
@@ -101,10 +101,10 @@ def test_update_liste_adds_missing_technician(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
     assert ws2.cell(row=2, column=1).value == "Osama"
-    assert excel_to_date(ws2.cell(row=2, column=2).value) == dt.date(2025, 7, 1)
-    assert ws2.cell(row=2, column=9).value == 2
-    assert ws2.cell(row=2, column=10).value == 1
+    assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=10).value == 2
     assert ws2.cell(row=2, column=11).value == 1
+    assert ws2.cell(row=2, column=12).value == 1
     wb2.close()
 
 
@@ -124,8 +124,8 @@ def test_update_liste_uses_technician_header_column(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
     assert ws2.cell(row=2, column=3).value == "Alice"
-    assert excel_to_date(ws2.cell(row=2, column=4).value) == dt.date(2025, 7, 1)
-    assert ws2.cell(row=2, column=11).value == 1
+    assert excel_to_date(ws2.cell(row=2, column=5).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=12).value == 1
     wb2.close()
 
 
@@ -135,8 +135,8 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     ws.title = "Juli_25"
     ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
-    ws.cell(row=2, column=2, value=dt.date(2025, 7, 1))
-    ws.cell(row=2, column=15, value=dt.date(2025, 7, 2))
+    ws.cell(row=2, column=3, value=dt.date(2025, 7, 1))
+    ws.cell(row=2, column=16, value=dt.date(2025, 7, 2))
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -147,8 +147,8 @@ def test_update_liste_multiple_runs(tmp_path: Path):
 
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
-    assert ws2.cell(row=2, column=9).value == 1
-    assert ws2.cell(row=2, column=22).value == 1
+    assert ws2.cell(row=2, column=10).value == 1
+    assert ws2.cell(row=2, column=23).value == 1
     wb2.close()
 
 
@@ -159,8 +159,8 @@ def test_update_liste_uses_matching_date(tmp_path: Path):
     ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
     ws.cell(row=3, column=1, value="Alice")
-    ws.cell(row=2, column=2, value=dt.date(2025, 7, 2))
-    ws.cell(row=3, column=2, value=dt.date(2025, 7, 1))
+    ws.cell(row=2, column=3, value=dt.date(2025, 7, 2))
+    ws.cell(row=3, column=3, value=dt.date(2025, 7, 1))
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -171,13 +171,13 @@ def test_update_liste_uses_matching_date(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
     # Erste Zeile mit abweichendem Datum wird überschrieben und beschrieben
-    assert excel_to_date(ws2.cell(row=2, column=2).value) == dt.date(2025, 7, 1)
-    assert ws2.cell(row=2, column=9).value == 5
-    assert ws2.cell(row=2, column=10).value == 3
-    assert ws2.cell(row=2, column=11).value == 2
+    assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=10).value == 5
+    assert ws2.cell(row=2, column=11).value == 3
+    assert ws2.cell(row=2, column=12).value == 2
     # Zweite Zeile bleibt unberührt
-    assert excel_to_date(ws2.cell(row=3, column=2).value) == dt.date(2025, 7, 1)
-    assert ws2.cell(row=3, column=9).value is None
+    assert excel_to_date(ws2.cell(row=3, column=3).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=3, column=10).value is None
     wb2.close()
 
 
@@ -196,10 +196,10 @@ def test_update_liste_creates_missing_sheet(tmp_path: Path):
     assert ws.cell(row=1, column=1).value == "Techniker"
     assert ws.max_row == 2
     assert ws.cell(row=2, column=1).value == "Alice"
-    assert excel_to_date(ws.cell(row=2, column=2).value) == dt.date(2025, 7, 1)
-    assert ws.cell(row=2, column=9).value == 2
-    assert ws.cell(row=2, column=10).value == 1
+    assert excel_to_date(ws.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
+    assert ws.cell(row=2, column=10).value == 2
     assert ws.cell(row=2, column=11).value == 1
+    assert ws.cell(row=2, column=12).value == 1
     wb2.close()
 
 
@@ -221,7 +221,7 @@ def test_update_liste_fills_invalid_date_cell(tmp_path: Path, caplog, date_value
     ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
     if date_value is not None:
-        ws.cell(row=2, column=2, value=date_value)
+        ws.cell(row=2, column=3, value=date_value)
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -243,10 +243,10 @@ def test_update_liste_fills_invalid_date_cell(tmp_path: Path, caplog, date_value
 
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
-    assert excel_to_date(ws2.cell(row=2, column=2).value) == dt.date(2025, 7, 1)
-    assert ws2.cell(row=2, column=9).value == 1
+    assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
     assert ws2.cell(row=2, column=10).value == 1
-    assert ws2.cell(row=2, column=11).value == 0
+    assert ws2.cell(row=2, column=11).value == 1
+    assert ws2.cell(row=2, column=12).value == 0
     wb2.close()
 
     assert "setze Datum" in caplog.text


### PR DESCRIPTION
## Zusammenfassung
- Kopfzeile nach "Techniker" durchsucht und Spaltenindex als `tech_col` gespeichert.
- Startspalte relativ zur Technikerspalte (+1) berechnet und in `update_liste` verwendet.
- Tests auf neue Spaltenpositionen angepasst.

## Testen
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d406294083308d1df57b4c8fab70