### PR TITLE
update_liste stellt Technikerspalte sicher

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -56,3 +56,4 @@
 2025-08-10 - Technikerspalte dynamisch ermittelt und Startspalte relativ zu ihr berechnet; Tests angepasst, neuer Test; pytest 58 bestanden.
 2025-08-10 - update_liste fügt verbleibende Techniker per ws.append als neue Zeilen hinzu und normalisiert Namen via canonical_name; pytest 58 bestanden.
 2025-08-10 - Startspalte richtet sich jetzt an Technikerspalte + 1 aus; Tests angepasst; pytest 58 bestanden.
+2025-08-10 - update_liste stellt sicher, dass eine Technikerspalte existiert oder fügt sie bei Bedarf als erste Spalte ein; Test ergänzt; pytest 59 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -341,11 +341,10 @@ def update_liste(
     try:
         if month_sheet not in wb.sheetnames:
             ws = wb.create_sheet(title=month_sheet)
-            ws.cell(row=1, column=1, value="Techniker")
         else:
             ws = wb[month_sheet]
 
-        # Bestimme die Spalte mit dem Header "Techniker"
+        # Sicherstellen, dass eine Spalte "Techniker" existiert
         tech_col = None
         for col in range(1, ws.max_column + 1):
             value = ws.cell(row=1, column=col).value
@@ -353,7 +352,10 @@ def update_liste(
                 tech_col = col
                 break
         if tech_col is None:
-            raise ValueError("Spalte 'Techniker' nicht gefunden")
+            if ws.cell(row=1, column=1).value not in (None, ""):
+                ws.insert_cols(1)
+            ws.cell(row=1, column=1, value="Techniker")
+            tech_col = 1
 
         # Canonicalise technician names already present in the sheet
         names_in_sheet: list[str] = []

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -181,6 +181,30 @@ def test_update_liste_uses_matching_date(tmp_path: Path):
     wb2.close()
 
 
+def test_update_liste_inserts_missing_technician_column(tmp_path: Path):
+    file = tmp_path / "liste.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Name")
+    wb.save(file)
+
+    morning = {"Alice": {"total": 2, "new": 1, "old": 1}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert ws2.cell(row=1, column=1).value == "Techniker"
+    assert ws2.cell(row=1, column=2).value == "Name"
+    assert ws2.cell(row=2, column=1).value == "Alice"
+    assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=10).value == 2
+    assert ws2.cell(row=2, column=11).value == 1
+    assert ws2.cell(row=2, column=12).value == 1
+    wb2.close()
+
+
 def test_update_liste_creates_missing_sheet(tmp_path: Path):
     file = tmp_path / "liste.xlsx"
     wb = Workbook()


### PR DESCRIPTION
## Zusammenfassung
- update_liste überprüft nun nach dem Laden des Arbeitsblatts, ob eine Spalte "Techniker" existiert und fügt sie bei Bedarf als erste Spalte ein.
- Neuer Test stellt sicher, dass die Technikerspalte automatisch angelegt wird.
- Arbeitsprotokoll um diesen Schritt ergänzt.

## Testplan
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d63f07508330816936a6c733c0e1