### PR TITLE
Berücksichtigt Leer-Spalten zwischen Tagen und Wochen

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -57,3 +57,4 @@
 2025-08-10 - update_liste fügt verbleibende Techniker per ws.append als neue Zeilen hinzu und normalisiert Namen via canonical_name; pytest 58 bestanden.
 2025-08-10 - Startspalte richtet sich jetzt an Technikerspalte + 1 aus; Tests angepasst; pytest 58 bestanden.
 2025-08-10 - update_liste stellt sicher, dass eine Technikerspalte existiert oder fügt sie bei Bedarf als erste Spalte ein; Test ergänzt; pytest 59 bestanden.
+2025-08-10 - Startspaltenberechnung in update_liste berücksichtigt nun 14 Spalten pro Tag und zusätzliche Leer-Spalten zwischen Wochen; Tests erweitert, Tages- und Wochen-Leer-Spalten simuliert; pytest 60 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -9,17 +9,16 @@ business day) versus "old". The evening report lists the still-open calls so the
 script can derive how many were completed during the day.
 
 The aggregated values are written into ``Liste.xlsx`` on the sheet for the
-corresponding month. The workbook contains weekly column blocks consisting of
-13 columns:
+corresponding month. The workbook contains weekly column blocks. Each day
+occupies 13 data columns followed by a blank column:
 
     name, date, weekday, pudo, pickup time, valid, info, pre-closed,
     total calls, old calls, new calls, details, mails
 
-Blocks sind zu Wochen gruppiert, zwischen denen eine Leer-Spalte liegt. Eine
-Woche besteht somit aus sieben 13-Spalten-Blöcken plus einer zusätzlichen
-Leer-Spalte. Für ein Datum ``d`` ergibt sich der Wochenindex ``(d.day-1)//7``
-und der Tagesindex ``(d.day-1)%7``. Die Startspalte lautet folglich
-``1 + week_index*(13*7 + 1) + day_index*13``.
+Seven such day blocks form a week, and an additional blank column separates
+the weeks. For a date ``d`` the week index is ``(d.day-1)//7`` and the day
+index ``(d.day-1)%7``. The starting column is therefore calculated as
+``1 + week_index*((13 + 1) * 7 + 1) + day_index*(13 + 1)``.
 
 The script requires :mod:`openpyxl` for reading and writing Excel files.
 """
@@ -380,13 +379,18 @@ def update_liste(
         morning = canonicalize_summary(morning)
 
         # Startspalte relativ zur Technikerspalte gemäß dem in ``Liste.xlsx``
-        # verwendeten Layout bestimmen. Tageswerte stehen in 13-Spalten-Blöcken,
-        # sieben Blöcke bilden eine Woche, zwischen Wochen liegt eine Leer-Spalte.
-        # Der Wochenindex und der Tagesindex innerhalb der Woche verschieben den
+        # verwendeten Layout bestimmen. Jede Tagesgruppe umfasst 13 Daten-
+        # spalten plus eine Leer-Spalte. Sieben solche Gruppen bilden eine
+        # Woche, zwischen den Wochen liegt eine weitere Leer-Spalte. Der
+        # Wochenindex und der Tagesindex innerhalb der Woche verschieben den
         # Start entsprechend.
         week_index = (day.day - 1) // 7
         day_index = (day.day - 1) % 7
-        start_col = tech_col + 1 + week_index * (13 * 7 + 1) + day_index * 13
+        start_col = (
+            tech_col + 1
+            + week_index * ((13 + 1) * 7 + 1)
+            + day_index * (13 + 1)
+        )
         remaining = set(morning)
 
         for row in range(2, ws.max_row + 1):

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -136,7 +136,7 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     ws.cell(row=1, column=1, value="Techniker")
     ws.cell(row=2, column=1, value="Alice")
     ws.cell(row=2, column=3, value=dt.date(2025, 7, 1))
-    ws.cell(row=2, column=16, value=dt.date(2025, 7, 2))
+    ws.cell(row=2, column=17, value=dt.date(2025, 7, 2))
     file = tmp_path / "liste.xlsx"
     wb.save(file)
 
@@ -147,8 +147,32 @@ def test_update_liste_multiple_runs(tmp_path: Path):
 
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
+    assert ws2.cell(row=2, column=16).value is None
     assert ws2.cell(row=2, column=10).value == 1
-    assert ws2.cell(row=2, column=23).value == 1
+    assert ws2.cell(row=2, column=24).value == 1
+    wb2.close()
+
+
+def test_update_liste_week_boundary_blank_columns(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
+    ws.cell(row=2, column=1, value="Alice")
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 7), morning)
+    update_liste(file, "Juli_25", dt.date(2025, 7, 8), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert ws2.cell(row=2, column=94).value == 1
+    assert ws2.cell(row=2, column=100).value is None
+    assert ws2.cell(row=2, column=101).value is None
+    assert ws2.cell(row=2, column=109).value == 1
     wb2.close()
 
 


### PR DESCRIPTION
## Zusammenfassung
- Startspalte in `update_liste` berücksichtigt nun 14 Spalten pro Tag sowie eine zusätzliche Leer-Spalte zwischen Wochen.
- Tests simulieren Arbeitsblätter mit Leer-Spalten und prüfen korrekte Positionierung der Tages- und Wochenblöcke.
- arbeitsprotokoll.txt um aktuellen Arbeitsschritt ergänzt.

## Test
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897dd5bf7c083308f4fe72fba01714c