### PR TITLE
Erkenne "Name" als Technikerspalte

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -59,3 +59,4 @@
 2025-08-10 - update_liste stellt sicher, dass eine Technikerspalte existiert oder fügt sie bei Bedarf als erste Spalte ein; Test ergänzt; pytest 59 bestanden.
 2025-08-10 - Startspaltenberechnung in update_liste berücksichtigt nun 14 Spalten pro Tag und zusätzliche Leer-Spalten zwischen Wochen; Tests erweitert, Tages- und Wochen-Leer-Spalten simuliert; pytest 60 bestanden.
 2025-08-10 - Test für 13-Spalten-Blöcke mit Leer-Spalten zwischen Tagen ergänzt; update_liste für späteren Tag geprüft; pytest 61 bestanden.
+2025-08-10 - update_liste nutzt "Name" als Technikerspalte und benennt sie um; Test prüft fehlende zusätzliche Spalte; pytest 61 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -343,13 +343,20 @@ def update_liste(
         else:
             ws = wb[month_sheet]
 
-        # Sicherstellen, dass eine Spalte "Techniker" existiert
+        # Sicherstellen, dass eine Spalte "Techniker" existiert.
+        # Neben "Techniker" wird auch "Name" als mögliche Überschrift akzeptiert.
         tech_col = None
         for col in range(1, ws.max_column + 1):
             value = ws.cell(row=1, column=col).value
-            if isinstance(value, str) and value.strip().lower() == "techniker":
-                tech_col = col
-                break
+            if isinstance(value, str):
+                header = value.strip().lower()
+                if header == "techniker":
+                    tech_col = col
+                    break
+                if header == "name":
+                    tech_col = col
+                    ws.cell(row=1, column=col, value="Techniker")
+                    break
         if tech_col is None:
             if ws.cell(row=1, column=1).value not in (None, ""):
                 ws.insert_cols(1)

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -250,7 +250,7 @@ def test_update_liste_uses_matching_date(tmp_path: Path):
     wb2.close()
 
 
-def test_update_liste_inserts_missing_technician_column(tmp_path: Path):
+def test_update_liste_renames_name_column(tmp_path: Path):
     file = tmp_path / "liste.xlsx"
     wb = Workbook()
     ws = wb.active
@@ -265,7 +265,8 @@ def test_update_liste_inserts_missing_technician_column(tmp_path: Path):
     wb2 = load_workbook(file)
     ws2 = wb2["Juli_25"]
     assert ws2.cell(row=1, column=1).value == "Techniker"
-    assert ws2.cell(row=1, column=2).value == "Name"
+    # Es wurde keine zusätzliche Spalte eingefügt
+    assert ws2.cell(row=1, column=2).value is None
     assert ws2.cell(row=2, column=1).value == "Alice"
     assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
     assert ws2.cell(row=2, column=10).value == 2


### PR DESCRIPTION
## Zusammenfassung
- Erweitert `update_liste` um Erkennung der Überschrift "Name" und benennt sie automatisch in "Techniker" um.
- Test verifiziert, dass bei vorhandener "Name"-Spalte keine zusätzliche Spalte eingefügt wird.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897e3ab8c3483309bccb2774f6e7166