### PR TITLE
Validierung der Tagesblock-Kopfzeilen vor dem Schreiben

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -63,3 +63,4 @@
 2025-08-10 - update_liste belässt gültige, aber abweichende Datumswerte unverändert und protokolliert eine Warnung; zusätzliche Tests verhindern Überschreibungen; pytest 62 bestanden.
 
 2025-08-10 - update_liste erkennt optionale Namensspalte in Tagesblöcken, passt Datums- und Startspalten dynamisch an und prüft Kopfzeilen; pytest 62 bestanden.
+2025-08-10 - Hilfsfunktion prüft Kopfzeilen der Tagesblöcke und validiert Layout vor dem Schreiben; Tests ergänzt; pytest 64 bestanden.


### PR DESCRIPTION
## Zusammenfassung
- Hilfsfunktion `_validate_day_block_headers` prüft Namens-, Datums- und Wochentags-Kopfzeilen und passt Startspalte dynamisch an.
- `update_liste` nutzt die neue Validierung, bevor Werte in die Arbeitsmappe geschrieben werden.
- Tests ergänzen Szenarien mit zusätzlicher Namensspalte und fehlerhaften Kopfzeilen.

## Testdurchführung
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897eb01f8608330bd3c50b31c43c219