### PR TITLE
Toleranter Umgang mit fehlender Datumsspalte

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -64,3 +64,4 @@
 
 2025-08-10 - update_liste erkennt optionale Namensspalte in Tagesblöcken, passt Datums- und Startspalten dynamisch an und prüft Kopfzeilen; pytest 62 bestanden.
 2025-08-10 - Hilfsfunktion prüft Kopfzeilen der Tagesblöcke und validiert Layout vor dem Schreiben; Tests ergänzt; pytest 64 bestanden.
+2025-08-10 - _validate_day_block_headers akzeptiert fehlende Datumsspalte mit "weekday"; Test ergänzt; pytest 65 bestanden.

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -348,6 +348,32 @@ def test_update_liste_handles_name_column_in_day_block(tmp_path: Path):
     wb2.close()
 
 
+def test_update_liste_accepts_weekday_in_date_column(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
+    ws.cell(row=1, column=3, value="weekday")
+    ws.cell(row=1, column=4, value="Wochentag")
+    ws.cell(row=2, column=1, value="Alice")
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 2, "new": 1, "old": 1}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    # Datum wird trotz falsch benannter Kopfzeile korrekt eingetragen
+    assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=4).value == "Dienstag"
+    assert ws2.cell(row=2, column=10).value == 2
+    assert ws2.cell(row=2, column=11).value == 1
+    assert ws2.cell(row=2, column=12).value == 1
+    wb2.close()
+
+
 def test_update_liste_raises_on_invalid_header(tmp_path: Path):
     wb = Workbook()
     ws = wb.active


### PR DESCRIPTION
## Zusammenfassung
- Akzeptiert fehlende oder falsch benannte Datumsspalten in der Liste und wählt Spalten dynamisch.
- Verhindert das Überschreiben des Datums, wenn keine eigene Wochentagsspalte vorhanden ist.
- Testfall deckt Liste mit "weekday"-Spaltenkopf ab.

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897eefbad0483308f96d153f393fabb