### PR TITLE
Warnung bei fehlendem Tagesblock

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -68,3 +68,5 @@
 2025-08-10 - _validate_day_block_headers sucht Tagesblock über date-Überschriften, optionalen 'name' ignoriert; update_liste nutzt erkannte Spalten; Tests angepasst; pytest 64 bestanden.
 
 2025-08-10 - update_liste berücksichtigt prev_day_col und date_col bei max_col, Test für Fall mit prev_day_col rechts von total_col; pytest 65 bestanden.
+
+2025-08-10 - _validate_day_block_headers gibt bei fehlendem Tagesblock nur Warnung und Flag zurück; update_liste überspringt fehlende Blöcke; Test für fehlenden Tagesblock ergänzt; pytest 66 bestanden.

--- a/dispatch/tests/test_main_missing_files.py
+++ b/dispatch/tests/test_main_missing_files.py
@@ -138,8 +138,12 @@ def test_main_creates_missing_sheet(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
 
     monkeypatch.setattr("builtins.input", lambda _: "j")
-    with pytest.raises(ValueError):
-        main()
+    main()
+
+    wb2 = load_workbook(liste)
+    assert "Juli_25" in wb2.sheetnames
+    assert wb2["Juli_25"].max_row == 1
+    wb2.close()
 
 
 def test_main_selects_existing_sheet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -164,6 +164,26 @@ def test_update_liste_multiple_runs(tmp_path: Path):
     wb2.close()
 
 
+def test_update_liste_skips_missing_day_block(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
+    add_block_headers(ws, 3)
+    ws.cell(row=2, column=1, value="Alice")
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 2), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert ws2.cell(row=2, column=10).value is None
+    wb2.close()
+
+
 def test_update_liste_day_blocks_with_blank_columns(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
@@ -353,7 +373,7 @@ def test_update_liste_accepts_weekday_in_date_column(tmp_path: Path):
     wb2.close()
 
 
-def test_update_liste_raises_on_invalid_header(tmp_path: Path):
+def test_update_liste_skips_on_invalid_header(tmp_path: Path):
     wb = Workbook()
     ws = wb.active
     ws.title = "Juli_25"
@@ -367,8 +387,12 @@ def test_update_liste_raises_on_invalid_header(tmp_path: Path):
 
     morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
 
-    with pytest.raises(ValueError, match="Header"):
-        update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert ws2.max_row == 1
+    wb2.close()
 
 
 def test_excel_to_date_none():


### PR DESCRIPTION
## Zusammenfassung
- `_validate_day_block_headers` kann fehlende Tagesblöcke nun mit Warnung und Flag melden.
- `update_liste` überspringt Tage ohne entsprechenden Block statt abzubrechen.
- Neuer Test simuliert eine Arbeitsmappe ohne Tagesblock und prüft das Verhalten.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f88d507c8330b0ab711f1c7cbd74