### PR TITLE
Formel- und Wochentagswerte in update_liste behandeln

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -70,3 +70,4 @@
 2025-08-10 - update_liste berücksichtigt prev_day_col und date_col bei max_col, Test für Fall mit prev_day_col rechts von total_col; pytest 65 bestanden.
 
 2025-08-10 - _validate_day_block_headers gibt bei fehlendem Tagesblock nur Warnung und Flag zurück; update_liste überspringt fehlende Blöcke; Test für fehlenden Tagesblock ergänzt; pytest 66 bestanden.
+2025-08-10 - update_liste erkennt Formel- oder Wochentagswerte in Datumszellen, setzt Datum einmalig auf Tageswert und warnt pro Techniker nur einmal; Tests für Formeln und Wochentage ergänzt; pytest 68 bestanden.

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -405,7 +405,10 @@ def test_excel_to_date_invalid():
         excel_to_date("abc")
 
 
-@pytest.mark.parametrize("date_value", [None, "abc"])
+@pytest.mark.parametrize(
+    "date_value",
+    [None, "abc", '=TEXT(B3,"tttt")', "Mittwoch"],
+)
 def test_update_liste_fills_invalid_date_cell(tmp_path: Path, caplog, date_value):
     wb = Workbook()
     ws = wb.active
@@ -442,7 +445,7 @@ def test_update_liste_fills_invalid_date_cell(tmp_path: Path, caplog, date_value
     assert ws2.cell(row=2, column=12).value == 0
     wb2.close()
 
-    assert "setze Datum" in caplog.text
+    assert sum(1 for r in caplog.records if r.levelno == logging.WARNING) == 1
 
 
 def test_update_liste_prev_day_after_total(tmp_path: Path):


### PR DESCRIPTION
## Zusammenfassung
- Erkenne Formeln oder reine Wochentagsnamen in Datumszellen und ersetze sie durch das Tagesdatum
- Pro Tag und Techniker wird nur eine Warnung für solche Datumsprobleme ausgegeben
- Tests decken nun Formeltexte und Wochentagswerte ab

## Testplan
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897fb7d729083309cfdde3607a8f294