### PR TITLE
Funktion zum Eintragen von Call-Werten

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -74,3 +74,4 @@
 2025-08-10 - update_liste fasst identische Warnungen pro Tag zusammen; Zusammenfassung im Log; Test ergänzt; pytest 69 bestanden.
 2025-08-10 - Monat 2025-07 erfolgreich verarbeitet.
 2025-08-13 - Monat 2025-07 erfolgreich verarbeitet.
+2025-08-13 - write_calls trägt Call-Daten nach Name und Datum in Monatslisten ein; Test ergänzt. pytest 70 bestanden.

--- a/dispatch/tests/test_write_calls.py
+++ b/dispatch/tests/test_write_calls.py
@@ -1,0 +1,35 @@
+import datetime as dt
+from pathlib import Path
+import pandas as pd
+from openpyxl import Workbook, load_workbook
+from dispatch.write_calls import write_calls
+
+
+def _create_workbook(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli"
+    names = [f"Name{i}" for i in range(1, 27)]
+    for idx, name in enumerate(names, start=2):
+        ws.cell(row=idx, column=1, value=name)
+    # Namen für weitere Tage kopieren
+    for day in range(1, 7):
+        for idx, name in enumerate(names, start=2 + 26 * day):
+            ws.cell(row=idx, column=1, value=name)
+    wb.save(path)
+
+
+def test_write_calls(tmp_path: Path) -> None:
+    file = tmp_path / "Juli.xlsx"
+    _create_workbook(file)
+    records = pd.DataFrame(
+        [
+            {"name": "Name1", "date": dt.date(2025, 7, 1), "value": 5},
+            {"name": "Name2", "date": dt.date(2025, 7, 15), "value": 3},
+        ]
+    )
+    write_calls(file, records)
+    wb = load_workbook(file)
+    ws = wb["Juli"]
+    assert ws["B28"].value == 5
+    assert ws["AD29"].value == 3

--- a/dispatch/write_calls.py
+++ b/dispatch/write_calls.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import Mapping
+import pandas as pd
+from openpyxl import load_workbook
+
+# Zuordnung Woche -> (Startspalte Datum, Startspalte Call)
+WEEK_START_COLUMNS: Mapping[int, tuple[str, str]] = {
+    1: ("A", "B"),
+    2: ("O", "P"),
+    3: ("AC", "AD"),
+}
+
+
+def write_calls(workbook: Path | str, records: pd.DataFrame, sheet_name: str = "Juli") -> None:
+    """Trage Call-Werte anhand von Namen und Datum in das Monatsblatt ein.
+
+    ``records`` muss die Spalten ``name``, ``date`` und ``value`` enthalten.
+    """
+    wb = load_workbook(workbook)
+    ws = wb[sheet_name]
+
+    # Namen des ersten Blocks auslesen und auf Indizes abbilden
+    name_map: dict[str, int] = {}
+    for idx, row in enumerate(ws["A2":"A27"], start=0):
+        cell = row[0]
+        if cell.value:
+            name_map[str(cell.value).strip()] = idx
+
+    for _, rec in records.iterrows():
+        name = str(rec["name"]).strip()
+        date = pd.to_datetime(rec["date"]).date()
+        value = rec["value"]
+
+        if name not in name_map:
+            continue
+        week = ((date.day - 1) // 7) + 1
+        week_cols = WEEK_START_COLUMNS.get(week)
+        if not week_cols:
+            continue
+        _, call_col = week_cols
+        day_offset = date.weekday()
+        row = 2 + name_map[name] + 26 * day_offset
+        ws[f"{call_col}{row}"] = value
+
+    wb.save(workbook)


### PR DESCRIPTION
## Zusammenfassung
- Hilfsfunktion `write_calls` ergänzt Monatslisten anhand von Name und Datum
- Test prüft korrekte Zuordnung der Zellen
- Arbeitsprotokoll aktualisiert

## Test
- `pip install pandas openpyxl`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bc753ab5c83308a39e744f9b91316