### PR TITLE
Option zum Korrigieren abweichender Datumsangaben

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -76,3 +76,5 @@
 2025-08-13 - Monat 2025-07 erfolgreich verarbeitet.
 2025-08-13 - write_calls trägt Call-Daten nach Name und Datum in Monatslisten ein; Test ergänzt. pytest 70 bestanden.
 2025-08-13 - Monat 2025-08 mit Fehlern verarbeitet.
+
+2025-08-13 - process_reports erweitert um optionales Überschreiben abweichender Datumsangaben (--fix-mismatched-dates); Warnung bleibt bestehen; Tests für beide Modi ergänzt; pytest 72 bestanden.

--- a/dispatch/tests/test_main_missing_files.py
+++ b/dispatch/tests/test_main_missing_files.py
@@ -49,7 +49,9 @@ def test_main_missing_morning_file_uses_fallback(
         called["used"] = Path(path)
         return dt.date(2025, 7, 1), {}, []
 
-    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+    def fake_update_liste(
+        liste_path, month_sheet, target_date, morning_summary, fix_mismatched_dates=False
+    ):
         pass
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
@@ -76,7 +78,9 @@ def test_main_no_evening_file_ok(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     def fake_load_calls(path, valid_names=None):
         return dt.date(2025, 7, 1), {}, []
 
-    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+    def fake_update_liste(
+        liste_path, month_sheet, target_date, morning_summary, fix_mismatched_dates=False
+    ):
         pass
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
@@ -111,7 +115,9 @@ def test_main_custom_morning_pattern(tmp_path: Path, monkeypatch: pytest.MonkeyP
     def fake_load_calls(path, valid_names=None):
         return dt.date(2025, 7, 1), {}, []
 
-    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+    def fake_update_liste(
+        liste_path, month_sheet, target_date, morning_summary, fix_mismatched_dates=False
+    ):
         pass
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
@@ -165,7 +171,13 @@ def test_main_selects_existing_sheet(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     called = {}
 
-    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+    def fake_update_liste(
+        liste_path,
+        month_sheet,
+        target_date,
+        morning_summary,
+        fix_mismatched_dates=False,
+    ):
         called["month_sheet"] = month_sheet
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)

--- a/dispatch/tests/test_main_year_from_parent.py
+++ b/dispatch/tests/test_main_year_from_parent.py
@@ -32,7 +32,13 @@ def test_main_uses_year_from_parent(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
     called = {}
 
-    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+    def fake_update_liste(
+        liste_path,
+        month_sheet,
+        target_date,
+        morning_summary,
+        fix_mismatched_dates=False,
+    ):
         called["month_sheet"] = month_sheet
         called["target_date"] = target_date
 

--- a/dispatch/tests/test_process_month.py
+++ b/dispatch/tests/test_process_month.py
@@ -38,7 +38,9 @@ def test_process_month_multiple_days(
 
     calls: list[dt.date] = []
 
-    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+    def fake_update_liste(
+        liste_path, month_sheet, target_date, morning_summary, fix_mismatched_dates=False
+    ):
         calls.append(target_date)
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
@@ -65,7 +67,9 @@ def test_process_month_logging(
     def fake_load_calls(path, valid_names=None):
         return dt.date(2025, 7, 1), {}, []
 
-    def fake_update_liste(liste_path, month_sheet, target_date, morning_summary):
+    def fake_update_liste(
+        liste_path, month_sheet, target_date, morning_summary, fix_mismatched_dates=False
+    ):
         pass
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)

--- a/dispatch/tests/test_process_reports.py
+++ b/dispatch/tests/test_process_reports.py
@@ -1,0 +1,92 @@
+import datetime as dt
+from pathlib import Path
+
+from openpyxl import Workbook, load_workbook
+import pytest
+import logging
+
+from dispatch.process_reports import update_liste, excel_to_date
+
+
+def add_block_headers(ws, date_col: int) -> None:
+    ws.cell(row=1, column=date_col, value="date")
+    ws.cell(row=1, column=date_col + 1, value="weekday")
+    ws.cell(row=1, column=date_col + 7, value="total calls")
+    ws.cell(row=1, column=date_col + 8, value="old calls")
+    ws.cell(row=1, column=date_col + 9, value="new calls")
+
+
+def test_mismatched_date_skipped(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
+    add_block_headers(ws, 3)
+    ws.cell(row=2, column=1, value="Alice")
+    ws.cell(row=2, column=3, value=dt.date(2025, 7, 2))
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
+
+    import dispatch.process_reports as pr
+
+    logger = pr.logger
+    original_handlers = logger.handlers[:]
+    original_propagate = logger.propagate
+    logger.handlers = []
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="dispatch.process_reports"):
+            update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+    finally:
+        logger.handlers = original_handlers
+        logger.propagate = original_propagate
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 2)
+    assert ws2.cell(row=2, column=10).value is None
+    assert "Abweichende Datumsangabe" in caplog.text
+    wb2.close()
+
+
+def test_mismatched_date_fixed(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
+    add_block_headers(ws, 3)
+    ws.cell(row=2, column=1, value="Alice")
+    ws.cell(row=2, column=3, value=dt.date(2025, 7, 2))
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {"Alice": {"total": 1, "new": 0, "old": 1}}
+
+    import dispatch.process_reports as pr
+
+    logger = pr.logger
+    original_handlers = logger.handlers[:]
+    original_propagate = logger.propagate
+    logger.handlers = []
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="dispatch.process_reports"):
+            update_liste(
+                file,
+                "Juli_25",
+                dt.date(2025, 7, 1),
+                morning,
+                fix_mismatched_dates=True,
+            )
+    finally:
+        logger.handlers = original_handlers
+        logger.propagate = original_propagate
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert excel_to_date(ws2.cell(row=2, column=3).value) == dt.date(2025, 7, 1)
+    assert ws2.cell(row=2, column=10).value == 1
+    assert "Abweichende Datumsangabe" in caplog.text
+    wb2.close()


### PR DESCRIPTION
## Zusammenfassung
- CLI-Schalter `--fix-mismatched-dates` ergänzt
- Abweichende Datumsangaben können optional überschrieben werden
- Tests für beide Modi hinzugefügt

## Test
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcb168eac8330964d46ece9b71507