### PR TITLE
CLI-Optionen für Blattwahl

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -81,3 +81,4 @@
 2025-08-12 - _validate_day_block_headers legt fehlende Tagesblöcke automatisch an und ergänzt Kopfzeilen; Tests simulieren Block-Erstellung; pytest 73 bestanden.
 2025-08-13 - Bereits geladene Techniker in Monatslisten werden kanonisiert, Duplikate zusammengeführt und Warnungen bei Kollisionen ausgegeben; Regressionstest für Namenskanonisierung ergänzt; pytest 73 bestanden.
 2025-08-13 - process_reports protokolliert Laufstart und verarbeitete Tage in arbeitsprotokoll.txt; README erwähnt Protokolldatei; pytest 74 bestanden.
+2025-08-14 - interaktive Blattwahl entfernt, CLI-Optionen --sheet und --create-sheet eingeführt; Tests angepasst; pytest 74 bestanden.

--- a/dispatch/tests/test_main_missing_files.py
+++ b/dispatch/tests/test_main_missing_files.py
@@ -136,14 +136,17 @@ def test_main_creates_missing_sheet(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     wb = Workbook()
     wb.save(day_dir / "morning7.xlsx")
 
-    monkeypatch.setattr(sys, "argv", ["process_reports.py", str(day_dir), str(liste)])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["process_reports.py", str(day_dir), str(liste), "--create-sheet"],
+    )
 
     def fake_load_calls(path, valid_names=None):
         return dt.date(2025, 7, 1), {"Alice": {"total": 1, "new": 1, "old": 0}}, []
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
 
-    monkeypatch.setattr("builtins.input", lambda _: "j")
     main()
 
     wb2 = load_workbook(liste)
@@ -166,7 +169,17 @@ def test_main_selects_existing_sheet(tmp_path: Path, monkeypatch: pytest.MonkeyP
     wb2 = Workbook()
     wb2.save(day_dir / "morning7.xlsx")
 
-    monkeypatch.setattr(sys, "argv", ["process_reports.py", str(day_dir), str(liste)])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "process_reports.py",
+            str(day_dir),
+            str(liste),
+            "--sheet",
+            "Juni_25",
+        ],
+    )
 
     def fake_load_calls(path, valid_names=None):
         return dt.date(2025, 7, 1), {}, []
@@ -184,7 +197,6 @@ def test_main_selects_existing_sheet(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr("dispatch.process_reports.load_calls", fake_load_calls)
     monkeypatch.setattr("dispatch.process_reports.update_liste", fake_update_liste)
-    monkeypatch.setattr("builtins.input", lambda _: "Juni_25")
     main()
 
     assert called["month_sheet"] == "Juni_25"


### PR DESCRIPTION
## Zusammenfassung
- Interaktive Blattwahl entfernt und Argumente `--sheet` und `--create-sheet` ergänzt.
- Fehlende Arbeitsblätter können nun optional automatisch angelegt werden.
- Tests für neue CLI-Optionen angepasst.

## Test
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bd2e7e1e48330a525decb36e2335c