### PR TITLE
Technikerzeilen in Liste nach Namen sortieren

### DIFF
--- a/arbeitsprotokoll.txt
+++ b/arbeitsprotokoll.txt
@@ -82,3 +82,4 @@
 2025-08-13 - Bereits geladene Techniker in Monatslisten werden kanonisiert, Duplikate zusammengeführt und Warnungen bei Kollisionen ausgegeben; Regressionstest für Namenskanonisierung ergänzt; pytest 73 bestanden.
 2025-08-13 - process_reports protokolliert Laufstart und verarbeitete Tage in arbeitsprotokoll.txt; README erwähnt Protokolldatei; pytest 74 bestanden.
 2025-08-14 - interaktive Blattwahl entfernt, CLI-Optionen --sheet und --create-sheet eingeführt; Tests angepasst; pytest 74 bestanden.
+2025-08-14 - update_liste sortiert Technikerzeilen alphabetisch und Test für unsortierte Zeilen ergänzt; pytest 75 bestanden.

--- a/dispatch/process_reports.py
+++ b/dispatch/process_reports.py
@@ -669,6 +669,25 @@ def update_liste(
             row_values[new_col - 1] = day_data["new"]
             ws.append(row_values)
             names_in_sheet.append(canon)
+        # Nach allen Einträgen die Datenzeilen anhand der Technikerspalte sortieren
+        last_row = ws.max_row
+        if last_row > 2:
+            data_rows = list(
+                ws.iter_rows(
+                    min_row=2,
+                    max_row=last_row,
+                    max_col=ws.max_column,
+                    values_only=True,
+                )
+            )
+            data_rows.sort(
+                key=lambda row: str(row[tech_col - 1]).casefold()
+                if row[tech_col - 1] is not None
+                else ""
+            )
+            ws.delete_rows(2, last_row - 1)
+            for row_values in data_rows:
+                ws.append(list(row_values))
 
         wb.save(liste)
     finally:

--- a/dispatch/tests/test_update_liste.py
+++ b/dispatch/tests/test_update_liste.py
@@ -117,6 +117,36 @@ def test_update_liste_adds_missing_technician(tmp_path: Path):
     wb2.close()
 
 
+def test_update_liste_sorts_rows(tmp_path: Path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Juli_25"
+    ws.cell(row=1, column=1, value="Techniker")
+    add_block_headers(ws, 3)
+    # unsortierte Ausgangsdaten
+    ws.cell(row=2, column=1, value="Bob")
+    ws.cell(row=2, column=3, value=dt.date(2025, 7, 1))
+    ws.cell(row=3, column=1, value="Alice")
+    ws.cell(row=3, column=3, value=dt.date(2025, 7, 1))
+    file = tmp_path / "liste.xlsx"
+    wb.save(file)
+
+    morning = {
+        "Bob": {"total": 2, "new": 1, "old": 1},
+        "Alice": {"total": 1, "new": 0, "old": 1},
+    }
+
+    update_liste(file, "Juli_25", dt.date(2025, 7, 1), morning)
+
+    wb2 = load_workbook(file)
+    ws2 = wb2["Juli_25"]
+    assert ws2.cell(row=2, column=1).value == "Alice"
+    assert ws2.cell(row=2, column=10).value == 1
+    assert ws2.cell(row=3, column=1).value == "Bob"
+    assert ws2.cell(row=3, column=10).value == 2
+    wb2.close()
+
+
 def test_update_liste_uses_technician_header_column(tmp_path: Path):
     wb = Workbook()
     ws = wb.active


### PR DESCRIPTION
## Zusammenfassung
- Datensätze in `update_liste` nach allen Einträgen anhand der Technikerspalte alphabetisch sortieren
- Unit-Test ergänzt, der unsortierte Zeilen prüft
- Arbeitsprotokoll erweitert

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bd3e3e78c83308f4ba782970ca97b