### PR TITLE
README aktualisiert: GUI entfernt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ Automatisiert die Auswertung von täglichen Anrufberichten der Servicetechniker 
 - Python 3.11 oder neuer
 - Abhängigkeiten laut `pyproject.toml` oder `requirements.txt`
 - Basisinstallation: `pip install -r requirements.txt`
-- Optionale GUI: `pip install --extra-index-url https://PySimpleGUI.net/install '.[gui]'`
 
 ## Kurzanleitung
 
 1. Lege die Tagesberichte in `data/reports/<YYYY-MM>/<TT>/` ab (z. B. `data/reports/2025-07/01`) mit Dateien `*7*.xlsx` (Standard, über `--morning-pattern` konfigurierbar) und optional `*19*.xlsx`.
-2. Starte die grafische Oberfläche mit `python run_all_gui.py`.
-3. Wähle einen Tag oder den gesamten Monat aus. Die Ergebnisse werden in `Liste.xlsx` geschrieben und der Ablauf im Arbeitsprotokoll `logs/arbeitsprotokoll.txt` festgehalten.
+2. Verarbeite einen Monat über die Kommandozeile, z. B.:
+
+```bash
+dispatch run-all data/reports/2025-07 data/Liste.xlsx
+```
+
+3. Die Ergebnisse landen in `Liste.xlsx`, der Ablauf im Arbeitsprotokoll `logs/arbeitsprotokoll.txt`.
 
 ## Automatische Monatsverarbeitung
 
@@ -29,7 +33,6 @@ Unter Windows steht die Batch-Datei `start_dispatch.bat` zur Verfügung. Sie fra
 
 - Virtuelle Umgebung: `python -m venv .venv` und Aktivierung mit `source .venv/bin/activate` (Linux/Mac) bzw. `\.venv\\Scripts\\activate` (Windows).
 - Abhängigkeiten installieren: `pip install -r requirements.txt` oder für Entwicklung `pip install -e .`.
-- Optionale GUI-Unterstützung: `pip install --extra-index-url https://PySimpleGUI.net/install '.[gui]'`.
 
 ## Testausführung
 

--- a/arbeitslog.md
+++ b/arbeitslog.md
@@ -8,3 +8,4 @@
 ## 2025-08-13
 - `run_current_month.pyw` zu `run_current_month.py` umbenannt und Wrapper `run_current_month.pyw` für `start_dispatch.bat` erstellt.
 - Import in `run_current_month.py` auf `from run_dispatch import process_month` sichergestellt.
+- Optionale GUI-Abhängigkeiten und `dispatch-gui`-Entry-Point entfernt, README entsprechend angepasst und `pip install -e .` ausgeführt.


### PR DESCRIPTION
## Zusammenfassung
- GUI-Referenzen aus README entfernt und CLI-Beispiel ergänzt.
- Arbeitslog um Entfernung der GUI-Abhängigkeiten und Ausführung von `pip install -e .` erweitert.

## Tests
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bdaca6fc48330b06a4f1f70c9b0e2